### PR TITLE
add vault address to aws-operator installation values

### DIFF
--- a/pkg/e2etemplates/aws_operator_chart_values.go
+++ b/pkg/e2etemplates/aws_operator_chart_values.go
@@ -4,6 +4,9 @@ package e2etemplates
 // variables will be expanded before writing the contents to a file.
 const AWSOperatorChartValues = `Installation:
   V1:
+    Auth:
+      Vault:
+        Address: http://vault.default.svc.cluster.local:8200
     Guest:
       Kubernetes:
         API:

--- a/pkg/e2etemplates/aws_operator_chart_values.go
+++ b/pkg/e2etemplates/aws_operator_chart_values.go
@@ -27,6 +27,7 @@ const AWSOperatorChartValues = `Installation:
         IncludeTags: true
         Route53:
           Enabled: true
+        Encrypter: 'kms'
     Secret:
       AWSOperator:
         IDRSAPub: ${IDRSA_PUB}


### PR DESCRIPTION
With the introduction of vault as an alternative encrypter backend in aws-operator we need to set the vault address value in the installation data for e2e tests, otherwise we get these errors on branch operator installation:
```
2018/06/14 11:26:15 Running command "helm registry install quay.io/giantswarm/aws-operator-chart@1.0.0-${CIRCLE_SHA1} -- -n aws-operator --values /tmp/aws-operator-values857294978"
usage: appr [-h]
            {pull,run-server,show,inspect,list,delete-package,helm,version,logout,deploy,plugins,push,login,config,channel,jsonnet}
            ...
appr: error: 
message: 'Error: render error in "aws-operator-chart/templates/03-configmap.yaml": template: aws-operator-chart/templates/03-configmap.yaml:23:33: executing "aws-operator-chart/templates/03-configmap.yaml" at <.Values.Installation...>: can''t evaluate field Vault in type interface {}
```