### PR TITLE
Add chartconfig e2e chart values

### DIFF
--- a/pkg/e2etemplates/apiextensions_chart_config_e2e_chart_values.go
+++ b/pkg/e2etemplates/apiextensions_chart_config_e2e_chart_values.go
@@ -3,15 +3,15 @@ package e2etemplates
 const ApiextensionsChartConfigE2EChartValues = `chart:
   channel: {{ .Channel }}
   configMap:
-    name: {{ .ConfigMapName }}
-    namespace: {{ .ConfigMapNamespace }}
-    resourceVersion: {{ .ConfigMapResourceVersion }}
+    name: {{ .ConfigMap.Name }}
+    namespace: {{ .ConfigMap.Namespace }}
+    resourceVersion: {{ .ConfigMap.ResourceVersion }}
   name: {{ .Name }}
   namespace: {{ .Namespace }}
   release: {{ .Release }}
   secret:
-    name: {{ .SecretName }}
-    namespace: {{ .SecretNamespace }}
-    resourceVersion: {{ .SecretResourceVersion }}
+    name: {{ .Secret.Name }}
+    namespace: {{ .Secret.Namespace }}
+    resourceVersion: {{ .Secret.ResourceVersion }}
 versionBundleVersion: {{ .VersionBundleVersion }}
 `

--- a/pkg/e2etemplates/apiextensions_chart_config_e2e_chart_values.go
+++ b/pkg/e2etemplates/apiextensions_chart_config_e2e_chart_values.go
@@ -1,0 +1,17 @@
+package e2etemplates
+
+const ApiextensionsChartConfigE2EChartValues = `chart:
+  channel: {{ .Channel }}
+  configMap:
+    name: {{ .ConfigMapName }}
+    namespace: {{ .ConfigMapNamespace }}
+    resourceVersion: {{ .ConfigMapResourceVersion }}
+  name: {{ .Name }}
+  namespace: {{ .Namespace }}
+  release: {{ .Release }}
+  secret:
+    name: {{ .SecretName }}
+    namespace: {{ .SecretNamespace }}
+    resourceVersion: {{ .SecretResourceVersion }}
+versionBundleVersion: {{ .VersionBundleVersion }}
+`


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/3390

I used this in my integration tests and it works as intended. No env vars necessary because everything is directly controlled by the test itself.