### PR TITLE
Add templating struct to ChartConfig template

### DIFF
--- a/pkg/e2etemplates/apiextensions_chart_config_e2e_chart_values.go
+++ b/pkg/e2etemplates/apiextensions_chart_config_e2e_chart_values.go
@@ -15,3 +15,25 @@ const ApiextensionsChartConfigE2EChartValues = `chart:
     resourceVersion: {{ .Secret.ResourceVersion }}
 versionBundleVersion: {{ .VersionBundleVersion }}
 `
+
+type ApiextensionsChartConfigValues struct {
+	Channel              string
+	ConfigMap            ApiextensionsChartConfigConfigMap
+	Name                 string
+	Namespace            string
+	Release              string
+	Secret               ApiextensionsChartConfigSecret
+	VersionBundleVersion string
+}
+
+type ApiextensionsChartConfigConfigMap struct {
+	Name            string
+	Namespace       string
+	ResourceVersion string
+}
+
+type ApiextensionsChartConfigSecret struct {
+	Name            string
+	Namespace       string
+	ResourceVersion string
+}


### PR DESCRIPTION
Basic idea: We use a go template here, we could put the struct used to template the values in here as well. 

Naming is an issue for me, how could I make this clearer? 