### PR TITLE
bring back AWS chart magic to unblock people

### DIFF
--- a/pkg/e2etemplates/apiextensions_aws_config_e2e_chart_values.go
+++ b/pkg/e2etemplates/apiextensions_aws_config_e2e_chart_values.go
@@ -1,0 +1,18 @@
+package e2etemplates
+
+const ApiextensionsAWSConfigE2EChartValues = `commonDomain: ${COMMON_DOMAIN}
+clusterName: ${CLUSTER_NAME}
+clusterVersion: v_0_1_0
+sshPublicKey: ${IDRSA_PUB}
+versionBundleVersion: ${VERSION_BUNDLE_VERSION}
+aws:
+  networkCIDR: "10.12.0.0/24"
+  privateSubnetCIDR: "10.12.0.0/25"
+  publicSubnetCIDR: "10.12.0.128/25"
+  region: ${AWS_REGION}
+  apiHostedZone: ${AWS_API_HOSTED_ZONE_GUEST}
+  ingressHostedZone: ${AWS_INGRESS_HOSTED_ZONE_GUEST}
+  routeTable0: ${AWS_ROUTE_TABLE_0}
+  routeTable1: ${AWS_ROUTE_TABLE_1}
+  vpcPeerId: ${AWS_VPC_PEER_ID}
+`

--- a/pkg/e2etemplates/aws_operator_chart_values.go
+++ b/pkg/e2etemplates/aws_operator_chart_values.go
@@ -1,0 +1,56 @@
+package e2etemplates
+
+// AWSOperatorChartValues values required by aws-operator-chart, the environment
+// variables will be expanded before writing the contents to a file.
+const AWSOperatorChartValues = `Installation:
+  V1:
+    Auth:
+      Vault:
+        Address: http://vault.default.svc.cluster.local:8200
+    Guest:
+      Kubernetes:
+        API:
+          Auth:
+            Provider:
+              OIDC:
+                ClientID: ""
+                IssueURL: ""
+                UsernameClaim: ""
+                GroupsClaim: ""
+      SSH:
+        SSOPublicKey: 'test'
+      Update:
+        Enabled: ${GUEST_UPDATE_ENABLED}
+    Name: ci-aws-operator
+    Provider:
+      AWS:
+        Region: ${AWS_REGION}
+        DeleteLoggingBucket: true
+        IncludeTags: true
+        Route53:
+          Enabled: true
+        Encrypter: 'kms'
+    Registry:
+      Domain: quay.io
+    Secret:
+      AWSOperator:
+        IDRSAPub: ${IDRSA_PUB}
+        SecretYaml: |
+          service:
+            aws:
+              accesskey:
+                id: ${GUEST_AWS_ACCESS_KEY_ID}
+                secret: ${GUEST_AWS_SECRET_ACCESS_KEY}
+                token: ${GUEST_AWS_SESSION_TOKEN}
+              hostaccesskey:
+                id: ${HOST_AWS_ACCESS_KEY_ID}
+                secret: ${HOST_AWS_SECRET_ACCESS_KEY}
+                token: ${HOST_AWS_SESSION_TOKEN}
+
+      Registry:
+        PullSecret:
+          DockerConfigJSON: "{\"auths\":{\"quay.io\":{\"auth\":\"${REGISTRY_PULL_SECRET}\"}}}"
+    Security:
+      RestrictAccess:
+        Enabled: false
+`


### PR DESCRIPTION
There were some changes which are not backwards compatible and which are not prepared in the operators. I need to move forward and have to update vendor deps and got trapped with this. Making it right as intended is a bit above me now and I do not want to spend this time. I just bring back how it was while keeping the other changes that were made. Once everything is sorted we can remove the old templates again. 