### PR TITLE
Add AWS Trusted Advisor flag to aws-operator chart

### DIFF
--- a/pkg/chartvalues/aws_operator.go
+++ b/pkg/chartvalues/aws_operator.go
@@ -22,13 +22,8 @@ type AWSOperatorConfigProvider struct {
 }
 
 type AWSOperatorConfigProviderAWS struct {
-	Encrypter      string
-	Region         string
-	TrustedAdvisor AWSOperatorConfigProviderAWSTrustedAdvisor
-}
-
-type AWSOperatorConfigProviderAWSTrustedAdvisor struct {
-	Enabled bool
+	Encrypter string
+	Region    string
 }
 
 type AWSOperatorConfigSecret struct {

--- a/pkg/chartvalues/aws_operator.go
+++ b/pkg/chartvalues/aws_operator.go
@@ -22,8 +22,13 @@ type AWSOperatorConfigProvider struct {
 }
 
 type AWSOperatorConfigProviderAWS struct {
-	Encrypter string
-	Region    string
+	Encrypter      string
+	Region         string
+	TrustedAdvisor AWSOperatorConfigProviderAWSTrustedAdvisor
+}
+
+type AWSOperatorConfigProviderAWSTrustedAdvisor struct {
+	Enabled bool
 }
 
 type AWSOperatorConfigSecret struct {

--- a/pkg/chartvalues/aws_operator_template.go
+++ b/pkg/chartvalues/aws_operator_template.go
@@ -33,6 +33,8 @@ const awsOperatorTemplate = `Installation:
         Route53:
           Enabled: true
         Encrypter: '{{ .Provider.AWS.Encrypter }}'
+        TrustedAdvisor:
+          Enabled: {{ .Provider.AWS.TrustedAdvisor.Enabled }}
     Registry:
       Domain: quay.io
     Secret:

--- a/pkg/chartvalues/aws_operator_template.go
+++ b/pkg/chartvalues/aws_operator_template.go
@@ -34,7 +34,7 @@ const awsOperatorTemplate = `Installation:
           Enabled: true
         Encrypter: '{{ .Provider.AWS.Encrypter }}'
         TrustedAdvisor:
-          Enabled: {{ .Provider.AWS.TrustedAdvisor.Enabled }}
+          Enabled: false
     Registry:
       Domain: quay.io
     Secret:

--- a/pkg/chartvalues/aws_operator_test.go
+++ b/pkg/chartvalues/aws_operator_test.go
@@ -13,7 +13,7 @@ func newAWSOperatorConfigFromFilled(modifyFunc func(*AWSOperatorConfig)) AWSOper
 				Encrypter: "vault",
 				Region:    "eu-central-1",
 				TrustedAdvisor: AWSOperatorConfigProviderAWSTrustedAdvisor{
-					Enabled: true,
+					Enabled: false,
 				},
 			},
 		},
@@ -95,7 +95,7 @@ func Test_NewAWSOperator(t *testing.T) {
           Enabled: true
         Encrypter: 'vault'
         TrustedAdvisor:
-          Enabled: true
+          Enabled: false
     Registry:
       Domain: quay.io
     Secret:
@@ -163,7 +163,7 @@ func Test_NewAWSOperator(t *testing.T) {
           Enabled: true
         Encrypter: 'kms'
         TrustedAdvisor:
-          Enabled: true
+          Enabled: false
     Registry:
       Domain: quay.io
     Secret:

--- a/pkg/chartvalues/aws_operator_test.go
+++ b/pkg/chartvalues/aws_operator_test.go
@@ -12,9 +12,6 @@ func newAWSOperatorConfigFromFilled(modifyFunc func(*AWSOperatorConfig)) AWSOper
 			AWS: AWSOperatorConfigProviderAWS{
 				Encrypter: "vault",
 				Region:    "eu-central-1",
-				TrustedAdvisor: AWSOperatorConfigProviderAWSTrustedAdvisor{
-					Enabled: false,
-				},
 			},
 		},
 		Secret: AWSOperatorConfigSecret{

--- a/pkg/chartvalues/aws_operator_test.go
+++ b/pkg/chartvalues/aws_operator_test.go
@@ -12,6 +12,9 @@ func newAWSOperatorConfigFromFilled(modifyFunc func(*AWSOperatorConfig)) AWSOper
 			AWS: AWSOperatorConfigProviderAWS{
 				Encrypter: "vault",
 				Region:    "eu-central-1",
+				TrustedAdvisor: AWSOperatorConfigProviderAWSTrustedAdvisor{
+					Enabled: true,
+				},
 			},
 		},
 		Secret: AWSOperatorConfigSecret{
@@ -91,6 +94,8 @@ func Test_NewAWSOperator(t *testing.T) {
         Route53:
           Enabled: true
         Encrypter: 'vault'
+        TrustedAdvisor:
+          Enabled: true
     Registry:
       Domain: quay.io
     Secret:
@@ -157,6 +162,8 @@ func Test_NewAWSOperator(t *testing.T) {
         Route53:
           Enabled: true
         Encrypter: 'kms'
+        TrustedAdvisor:
+          Enabled: true
     Registry:
       Domain: quay.io
     Secret:

--- a/pkg/e2etemplates/aws_operator_chart_values.go
+++ b/pkg/e2etemplates/aws_operator_chart_values.go
@@ -36,7 +36,7 @@ const AWSOperatorChartValues = `Installation:
           Enabled: true
         Encrypter: 'kms'
         TrustedAdvisor:
-          Enabled: true
+          Enabled: false
     Registry:
       Domain: quay.io
     Secret:

--- a/pkg/e2etemplates/aws_operator_chart_values.go
+++ b/pkg/e2etemplates/aws_operator_chart_values.go
@@ -35,6 +35,8 @@ const AWSOperatorChartValues = `Installation:
         Route53:
           Enabled: true
         Encrypter: 'kms'
+        TrustedAdvisor:
+          Enabled: true
     Registry:
       Domain: quay.io
     Secret:


### PR DESCRIPTION
To make aws-operator only enable trusted advisor metrics when it's
enabled, a configuration flag has been added to its chart. This way it
can adjust its behavior accordingly.

Therefore change to e2e template is also need so that e2e tests run
successfully in AWS. As our environment has it, it's always enabled
here.

Towards https://github.com/giantswarm/giantswarm/issues/4083