### PR TITLE
Add labelSelector to cert-operator chart values

### DIFF
--- a/pkg/e2etemplates/cert_operator_chart_values.go
+++ b/pkg/e2etemplates/cert_operator_chart_values.go
@@ -25,4 +25,5 @@ Installation:
       Registry:
         PullSecret:
           DockerConfigJSON: "{\"auths\":{\"quay.io\":{\"auth\":\"$REGISTRY_PULL_SECRET\"}}}"
+labelSelector: 'giantswarm.io/cluster=${CLUSTER_NAME}'
 `


### PR DESCRIPTION
In KVM e2e tests there are multiple instances of same operator running.
In order to prevent race conditions, an informer label selector can be
specified for operator so that it only processes CR objects for its own
e2e run.

Towards https://github.com/giantswarm/giantswarm/issues/4196#issuecomment-421297710