### PR TITLE
Add flannel operator go template

### DIFF
--- a/pkg/chartvalues/flannel_operator.go
+++ b/pkg/chartvalues/flannel_operator.go
@@ -1,0 +1,46 @@
+package chartvalues
+
+import (
+	"github.com/giantswarm/e2etemplates/internal/render"
+	"github.com/giantswarm/microerror"
+)
+
+type FlannelOperatorConfig struct {
+	ClusterName        string
+	ClusterRole        FlannelOperatorClusterRole
+	ClusterRolePSP     FlannelOperatorClusterRole
+	RegistryPullSecret string
+}
+
+type FlannelOperatorClusterRole struct {
+	BindingName string
+	Name        string
+}
+
+func NewFlannelOperator(config FlannelOperatorConfig) (string, error) {
+	if config.ClusterName == "" {
+		return "", microerror.Maskf(invalidConfigError, "%T.ClusterName must not be empty", config)
+	}
+	if config.ClusterRole.BindingName == "" {
+		return "", microerror.Maskf(invalidConfigError, "%T.ClusterRole.BindingName must not be empty", config)
+	}
+	if config.ClusterRole.Name == "" {
+		return "", microerror.Maskf(invalidConfigError, "%T.ClusterRole.Name must not be empty", config)
+	}
+	if config.ClusterRolePSP.BindingName == "" {
+		return "", microerror.Maskf(invalidConfigError, "%T.ClusterRolePSP.BindingName must not be empty", config)
+	}
+	if config.ClusterRolePSP.Name == "" {
+		return "", microerror.Maskf(invalidConfigError, "%T.ClusterRolePSP.Name must not be empty", config)
+	}
+	if config.RegistryPullSecret == "" {
+		return "", microerror.Maskf(invalidConfigError, "%T.RegistryPullSecret must not be empty", config)
+	}
+
+	values, err := render.Render(flannelOperatorTemplate, config)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	return values, nil
+}

--- a/pkg/chartvalues/flannel_operator_template.go
+++ b/pkg/chartvalues/flannel_operator_template.go
@@ -1,0 +1,17 @@
+package chartvalues
+
+const flannelOperatorTemplate = `clusterRoleBindingName: {{ .ClusterRole.BindingName }}
+clusterRoleBindingNamePSP: {{ .ClusterRolePSP.BindingName }}
+clusterRoleName: {{ .ClusterRole.Name }}
+clusterRoleNamePSP: {{ .ClusterRolePSP.Name }}
+Installation:
+  V1:
+    GiantSwarm:
+      FlannelOperator:
+        CRD:
+          LabelSelector: 'giantswarm.io/cluster={{ .ClusterName }}'
+    Secret:
+      Registry:
+        PullSecret:
+          DockerConfigJSON: "{\"auths\":{\"quay.io\":{\"auth\":\"{{ .RegistryPullSecret }}\"}}}"
+`

--- a/pkg/chartvalues/flannel_operator_test.go
+++ b/pkg/chartvalues/flannel_operator_test.go
@@ -1,0 +1,159 @@
+package chartvalues
+
+import (
+	"testing"
+
+	"github.com/giantswarm/e2etemplates/internal/rendertest"
+)
+
+func newFlannelOperatorConfigFromFilled(modifyFunc func(*FlannelOperatorConfig)) FlannelOperatorConfig {
+	c := FlannelOperatorConfig{
+		ClusterName: "test-cluster",
+		ClusterRole: FlannelOperatorClusterRole{
+			BindingName: "flannel-operator",
+			Name:        "flannel-operator",
+		},
+		ClusterRolePSP: FlannelOperatorClusterRole{
+			BindingName: "flannel-operator-psp",
+			Name:        "flannel-operator-psp",
+		},
+		RegistryPullSecret: "test-registry-pull-secret",
+	}
+
+	modifyFunc(&c)
+	return c
+}
+
+func Test_NewFlannelOperator(t *testing.T) {
+	testCases := []struct {
+		name           string
+		config         FlannelOperatorConfig
+		expectedValues string
+		errorMatcher   func(err error) bool
+	}{
+		{
+			name:           "case 0: invalid config",
+			config:         FlannelOperatorConfig{},
+			expectedValues: ``,
+			errorMatcher:   IsInvalidConfig,
+		},
+		{
+			name:   "case 1: all values set",
+			config: newFlannelOperatorConfigFromFilled(func(v *FlannelOperatorConfig) {}),
+			expectedValues: `clusterRoleBindingName: flannel-operator
+clusterRoleBindingNamePSP: flannel-operator-psp
+clusterRoleName: flannel-operator
+clusterRoleNamePSP: flannel-operator-psp
+Installation:
+  V1:
+    GiantSwarm:
+      FlannelOperator:
+        CRD:
+          LabelSelector: 'giantswarm.io/cluster=test-cluster'
+    Secret:
+      Registry:
+        PullSecret:
+          DockerConfigJSON: "{\"auths\":{\"quay.io\":{\"auth\":\"test-registry-pull-secret\"}}}"
+`,
+			errorMatcher: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			values, err := NewFlannelOperator(tc.config)
+
+			switch {
+			case err == nil && tc.errorMatcher == nil:
+				// correct; carry on
+			case err != nil && tc.errorMatcher == nil:
+				t.Fatalf("error == %#v, want nil", err)
+			case err == nil && tc.errorMatcher != nil:
+				t.Fatalf("error == nil, want non-nil")
+			case !tc.errorMatcher(err):
+				t.Fatalf("error == %#v, want matching", err)
+			}
+
+			if tc.errorMatcher != nil {
+				return
+			}
+
+			line, difference := rendertest.Diff(values, tc.expectedValues)
+			if line > 0 {
+				t.Fatalf("line == %d, want 0, diff: %s", line, difference)
+			}
+		})
+	}
+}
+
+func Test_NewFlannelOperator_invalidConfigError(t *testing.T) {
+	testCases := []struct {
+		name         string
+		config       FlannelOperatorConfig
+		errorMatcher func(err error) bool
+	}{
+		{
+			name: "case 0: invalid .ClusterName",
+			config: newFlannelOperatorConfigFromFilled(func(v *FlannelOperatorConfig) {
+				v.ClusterName = ""
+			}),
+			errorMatcher: IsInvalidConfig,
+		},
+		{
+			name: "case 1: invalid .ClusterRole.BindingName",
+			config: newFlannelOperatorConfigFromFilled(func(v *FlannelOperatorConfig) {
+				v.ClusterRole.BindingName = ""
+			}),
+			errorMatcher: IsInvalidConfig,
+		},
+		{
+			name: "case 2: invalid .ClusterRole.Name",
+			config: newFlannelOperatorConfigFromFilled(func(v *FlannelOperatorConfig) {
+				v.ClusterRole.Name = ""
+			}),
+			errorMatcher: IsInvalidConfig,
+		},
+		{
+			name: "case 3: invalid .ClusterRolePSP.BindingName",
+			config: newFlannelOperatorConfigFromFilled(func(v *FlannelOperatorConfig) {
+				v.ClusterRolePSP.BindingName = ""
+			}),
+			errorMatcher: IsInvalidConfig,
+		},
+		{
+			name: "case 4: invalid .ClusterRolePSP.Name",
+			config: newFlannelOperatorConfigFromFilled(func(v *FlannelOperatorConfig) {
+				v.ClusterRolePSP.Name = ""
+			}),
+			errorMatcher: IsInvalidConfig,
+		},
+		{
+			name: "case 5: invalid .RegistryPullSecret",
+			config: newFlannelOperatorConfigFromFilled(func(v *FlannelOperatorConfig) {
+				v.RegistryPullSecret = ""
+			}),
+			errorMatcher: IsInvalidConfig,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewFlannelOperator(tc.config)
+
+			switch {
+			case err == nil && tc.errorMatcher == nil:
+				// correct; carry on
+			case err != nil && tc.errorMatcher == nil:
+				t.Fatalf("error == %#v, want nil", err)
+			case err == nil && tc.errorMatcher != nil:
+				t.Fatalf("error == nil, want non-nil")
+			case !tc.errorMatcher(err):
+				t.Fatalf("error == %#v, want matching", err)
+			}
+
+			if tc.errorMatcher != nil {
+				return
+			}
+		})
+	}
+}


### PR DESCRIPTION
Basically the same as I did for KVM-Operator before. I still think it makes sense to keep them separated, as we add more E2E tests these will diverge IMO.