### PR TITLE
Add psp name to templating

### DIFF
--- a/pkg/chartvalues/kvm_operator.go
+++ b/pkg/chartvalues/kvm_operator.go
@@ -9,12 +9,17 @@ type KVMOperatorConfig struct {
 	ClusterName        string
 	ClusterRole        KVMOperatorClusterRole
 	ClusterRolePSP     KVMOperatorClusterRole
+	PSP                KVMOperatorPSP
 	RegistryPullSecret string
 }
 
 type KVMOperatorClusterRole struct {
 	BindingName string
 	Name        string
+}
+
+type KVMOperatorPSP struct {
+	Name string
 }
 
 func NewKVMOperator(config KVMOperatorConfig) (string, error) {
@@ -32,6 +37,9 @@ func NewKVMOperator(config KVMOperatorConfig) (string, error) {
 	}
 	if config.ClusterRolePSP.Name == "" {
 		return "", microerror.Maskf(invalidConfigError, "%T.ClusterRolePSP.Name must not be empty", config)
+	}
+	if config.PSP.Name == "" {
+		return "", microerror.Maskf(invalidConfigError, "%T.PSP.Name must not be empty", config)
 	}
 	if config.RegistryPullSecret == "" {
 		return "", microerror.Maskf(invalidConfigError, "%T.RegistryPullSecret must not be empty", config)

--- a/pkg/chartvalues/kvm_operator_template.go
+++ b/pkg/chartvalues/kvm_operator_template.go
@@ -28,4 +28,5 @@ Installation:
       Registry:
         PullSecret:
           DockerConfigJSON: "{\"auths\":{\"quay.io\":{\"auth\":\"{{ .RegistryPullSecret }}\"}}}"
+pspName: {{ .PSP.Name }}
 `

--- a/pkg/chartvalues/kvm_operator_test.go
+++ b/pkg/chartvalues/kvm_operator_test.go
@@ -18,6 +18,9 @@ func newKVMOperatorConfigFromFilled(modifyFunc func(*KVMOperatorConfig)) KVMOper
 			Name:        "kvm-operator-psp",
 		},
 		RegistryPullSecret: "test-registry-pull-secret",
+		PSP: KVMOperatorPSP{
+			Name: "kvm-test-psp",
+		},
 	}
 
 	modifyFunc(&c)
@@ -68,6 +71,7 @@ Installation:
       Registry:
         PullSecret:
           DockerConfigJSON: "{\"auths\":{\"quay.io\":{\"auth\":\"test-registry-pull-secret\"}}}"
+pspName: kvm-test-psp
 `,
 			errorMatcher: nil,
 		},
@@ -142,7 +146,14 @@ func Test_NewKVMOperator_invalidConfigError(t *testing.T) {
 			errorMatcher: IsInvalidConfig,
 		},
 		{
-			name: "case 5: invalid .RegistryPullSecret",
+			name: "case 5: invalid .PSP.Name",
+			config: newKVMOperatorConfigFromFilled(func(v *KVMOperatorConfig) {
+				v.PSP.Name = ""
+			}),
+			errorMatcher: IsInvalidConfig,
+		},
+		{
+			name: "case 6: invalid .RegistryPullSecret",
 			config: newKVMOperatorConfigFromFilled(func(v *KVMOperatorConfig) {
 				v.RegistryPullSecret = ""
 			}),


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/4388

PSP can not be unique either for KVM, so we need it to be configurable.