### PR TITLE
improves flannel templates with defaults

### DIFF
--- a/pkg/chartvalues/flannel_operator.go
+++ b/pkg/chartvalues/flannel_operator.go
@@ -9,8 +9,8 @@ type FlannelOperatorConfig struct {
 	ClusterName        string
 	ClusterRole        FlannelOperatorClusterRole
 	ClusterRolePSP     FlannelOperatorClusterRole
-	RegistryPullSecret string
 	PSP                FlannelOperatorPSP
+	RegistryPullSecret string
 }
 
 type FlannelOperatorClusterRole struct {
@@ -27,19 +27,19 @@ func NewFlannelOperator(config FlannelOperatorConfig) (string, error) {
 		return "", microerror.Maskf(invalidConfigError, "%T.ClusterName must not be empty", config)
 	}
 	if config.ClusterRole.BindingName == "" {
-		return "", microerror.Maskf(invalidConfigError, "%T.ClusterRole.BindingName must not be empty", config)
+		config.ClusterRole.BindingName = "flannel-operator"
 	}
 	if config.ClusterRole.Name == "" {
-		return "", microerror.Maskf(invalidConfigError, "%T.ClusterRole.Name must not be empty", config)
+		config.ClusterRole.Name = "flannel-operator"
 	}
 	if config.ClusterRolePSP.BindingName == "" {
-		return "", microerror.Maskf(invalidConfigError, "%T.ClusterRolePSP.BindingName must not be empty", config)
+		config.ClusterRolePSP.BindingName = "flannel-operator-psp"
 	}
 	if config.ClusterRolePSP.Name == "" {
-		return "", microerror.Maskf(invalidConfigError, "%T.ClusterRolePSP.Name must not be empty", config)
+		config.ClusterRolePSP.Name = "flannel-operator-psp"
 	}
 	if config.PSP.Name == "" {
-		return "", microerror.Maskf(invalidConfigError, "%T.PSP.Name must not be empty", config)
+		config.PSP.Name = "flannel-operator-psp"
 	}
 	if config.RegistryPullSecret == "" {
 		return "", microerror.Maskf(invalidConfigError, "%T.RegistryPullSecret must not be empty", config)

--- a/pkg/chartvalues/flannel_operator_test.go
+++ b/pkg/chartvalues/flannel_operator_test.go
@@ -108,35 +108,35 @@ func Test_NewFlannelOperator_invalidConfigError(t *testing.T) {
 			config: newFlannelOperatorConfigFromFilled(func(v *FlannelOperatorConfig) {
 				v.ClusterRole.BindingName = ""
 			}),
-			errorMatcher: IsInvalidConfig,
+			errorMatcher: nil,
 		},
 		{
 			name: "case 2: invalid .ClusterRole.Name",
 			config: newFlannelOperatorConfigFromFilled(func(v *FlannelOperatorConfig) {
 				v.ClusterRole.Name = ""
 			}),
-			errorMatcher: IsInvalidConfig,
+			errorMatcher: nil,
 		},
 		{
 			name: "case 3: invalid .ClusterRolePSP.BindingName",
 			config: newFlannelOperatorConfigFromFilled(func(v *FlannelOperatorConfig) {
 				v.ClusterRolePSP.BindingName = ""
 			}),
-			errorMatcher: IsInvalidConfig,
+			errorMatcher: nil,
 		},
 		{
 			name: "case 4: invalid .ClusterRolePSP.Name",
 			config: newFlannelOperatorConfigFromFilled(func(v *FlannelOperatorConfig) {
 				v.ClusterRolePSP.Name = ""
 			}),
-			errorMatcher: IsInvalidConfig,
+			errorMatcher: nil,
 		},
 		{
 			name: "case 5: invalid .PSP.Name",
 			config: newFlannelOperatorConfigFromFilled(func(v *FlannelOperatorConfig) {
 				v.PSP.Name = ""
 			}),
-			errorMatcher: IsInvalidConfig,
+			errorMatcher: nil,
 		},
 		{
 			name: "case 6: invalid .RegistryPullSecret",


### PR DESCRIPTION
This is the same as with `cert-operator`. I want to ease the setup for KVM a bit. 