### PR TITLE
adds e2e certs chart values

### DIFF
--- a/pkg/chartvalues/e2esetup_certs.go
+++ b/pkg/chartvalues/e2esetup_certs.go
@@ -1,0 +1,33 @@
+package chartvalues
+
+import (
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/e2etemplates/internal/render"
+)
+
+type E2ESetupCertsConfig struct {
+	Cluster      E2ESetupCertsConfigCluster
+	CommonDomain string
+}
+
+type E2ESetupCertsConfigCluster struct {
+	ID string
+}
+
+// NewE2ESetupCerts renders values required by e2esetup-certs-chart.
+func NewE2ESetupCerts(config E2ESetupCertsConfig) (string, error) {
+	if config.Cluster.ID == "" {
+		return "", microerror.Maskf(invalidConfigError, "%T.Cluster.ID must not be empty", config)
+	}
+	if config.CommonDomain == "" {
+		return "", microerror.Maskf(invalidConfigError, "%T.CommonDomain must not be empty", config)
+	}
+
+	values, err := render.Render(e2eSetupCertsTemplate, config)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	return values, nil
+}

--- a/pkg/chartvalues/e2esetup_certs_template.go
+++ b/pkg/chartvalues/e2esetup_certs_template.go
@@ -1,0 +1,11 @@
+package chartvalues
+
+const e2eSetupCertsTemplate = `
+cluster:
+  id: {{ .Cluster.ID }}
+commonDomain: {{ .CommonDomain }}
+ipSans:
+  - "172.31.0.1"
+organizations:
+  - "system:masters"
+`

--- a/pkg/chartvalues/e2esetup_certs_test.go
+++ b/pkg/chartvalues/e2esetup_certs_test.go
@@ -29,7 +29,7 @@ func Test_NewE2ESetupCerts(t *testing.T) {
 		{
 			name:           "case 0: invalid config",
 			config:         E2ESetupCertsConfig{},
-			expectedValues: ``,
+			expectedValues: "",
 			errorMatcher:   IsInvalidConfig,
 		},
 		{

--- a/pkg/chartvalues/e2esetup_certs_test.go
+++ b/pkg/chartvalues/e2esetup_certs_test.go
@@ -1,0 +1,120 @@
+package chartvalues
+
+import (
+	"testing"
+
+	"github.com/giantswarm/e2etemplates/internal/rendertest"
+)
+
+func newE2ESetupCertsConfigFromFilled(modifyFunc func(*E2ESetupCertsConfig)) E2ESetupCertsConfig {
+	c := E2ESetupCertsConfig{
+		Cluster: E2ESetupCertsConfigCluster{
+			ID: "test-id",
+		},
+		CommonDomain: "test-common-domain",
+	}
+
+	modifyFunc(&c)
+
+	return c
+}
+
+func Test_NewE2ESetupCerts(t *testing.T) {
+	testCases := []struct {
+		name           string
+		config         E2ESetupCertsConfig
+		expectedValues string
+		errorMatcher   func(err error) bool
+	}{
+		{
+			name:           "case 0: invalid config",
+			config:         E2ESetupCertsConfig{},
+			expectedValues: ``,
+			errorMatcher:   IsInvalidConfig,
+		},
+		{
+			name:   "case 1: all values set",
+			config: newE2ESetupCertsConfigFromFilled(func(v *E2ESetupCertsConfig) {}),
+			expectedValues: `
+cluster:
+  id: test-id
+commonDomain: test-common-domain
+ipSans:
+  - "172.31.0.1"
+organizations:
+  - "system:masters"
+`,
+			errorMatcher: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			values, err := NewE2ESetupCerts(tc.config)
+
+			switch {
+			case err == nil && tc.errorMatcher == nil:
+				// correct; carry on
+			case err != nil && tc.errorMatcher == nil:
+				t.Fatalf("error == %#v, want nil", err)
+			case err == nil && tc.errorMatcher != nil:
+				t.Fatalf("error == nil, want non-nil")
+			case !tc.errorMatcher(err):
+				t.Fatalf("error == %#v, want matching", err)
+			}
+
+			if tc.errorMatcher != nil {
+				return
+			}
+
+			line, difference := rendertest.Diff(values, tc.expectedValues)
+			if line > 0 {
+				t.Fatalf("line == %d, want 0, diff: %s", line, difference)
+			}
+		})
+	}
+}
+
+func Test_NewE2ESetupCerts_invalidConfigError(t *testing.T) {
+	testCases := []struct {
+		name         string
+		config       E2ESetupCertsConfig
+		errorMatcher func(err error) bool
+	}{
+		{
+			name: "case 0: invalid .Cluster.ID",
+			config: newE2ESetupCertsConfigFromFilled(func(v *E2ESetupCertsConfig) {
+				v.Cluster.ID = ""
+			}),
+			errorMatcher: IsInvalidConfig,
+		},
+		{
+			name: "case 1: invalid .CommonDomain",
+			config: newE2ESetupCertsConfigFromFilled(func(v *E2ESetupCertsConfig) {
+				v.CommonDomain = ""
+			}),
+			errorMatcher: IsInvalidConfig,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewE2ESetupCerts(tc.config)
+
+			switch {
+			case err == nil && tc.errorMatcher == nil:
+				// correct; carry on
+			case err != nil && tc.errorMatcher == nil:
+				t.Fatalf("error == %#v, want nil", err)
+			case err == nil && tc.errorMatcher != nil:
+				t.Fatalf("error == nil, want non-nil")
+			case !tc.errorMatcher(err):
+				t.Fatalf("error == %#v, want matching", err)
+			}
+
+			if tc.errorMatcher != nil {
+				return
+			}
+		})
+	}
+}


### PR DESCRIPTION
Like Vault, we want to put the e2e charts into here. To make IPAM e2e tests work we need to not only make the tenant cluster creation dynamic, which is already done, but also sort the `CertConfig` CRs accordingly. See also https://github.com/giantswarm/giantswarm/pull/2202. See also https://github.com/giantswarm/e2esetup/pull/11. 