### PR TITLE
makes label selector optional for cert-operator

### DIFF
--- a/internal/rendertest/diff.go
+++ b/internal/rendertest/diff.go
@@ -3,6 +3,7 @@ package rendertest
 import (
 	"fmt"
 	"strings"
+	"unicode"
 )
 
 func Diff(a, b string) (int, string) {
@@ -15,8 +16,10 @@ func Diff(a, b string) (int, string) {
 	}
 
 	for i := 0; i < length; i++ {
-		if aSplit[i] != bSplit[i] {
-			return i + 1, fmt.Sprintf("a: %q b: %q", aSplit[i], bSplit[i])
+		a := strings.TrimRightFunc(aSplit[i], unicode.IsSpace)
+		b := strings.TrimRightFunc(bSplit[i], unicode.IsSpace)
+		if a != b {
+			return i + 1, fmt.Sprintf("a: %q b: %q", a, b)
 		}
 	}
 

--- a/pkg/chartvalues/cert_operator.go
+++ b/pkg/chartvalues/cert_operator.go
@@ -6,19 +6,27 @@ import (
 )
 
 type CertOperatorConfig struct {
-	ClusterName        string
-	ClusterRole        CertOperatorClusterRole
-	ClusterRolePSP     CertOperatorClusterRole
+	ClusterRole        CertOperatorConfigClusterRole
+	ClusterRolePSP     CertOperatorConfigClusterRole
 	CommonDomain       string
+	CRD                CertOperatorConfigCRD
 	Namespace          string
 	RegistryPullSecret string
 	PSP                CertOperatorPSP
 	Vault              CertOperatorVault
 }
 
-type CertOperatorClusterRole struct {
+type CertOperatorConfigClusterRole struct {
 	BindingName string
 	Name        string
+}
+
+type CertOperatorConfigCRD struct {
+	// LabelSelector configures the operator's list watcher label selector to
+	// consider only specific CRs. This is done e.g. for the kvm-operator e2e
+	// tests due to the lack of test env encapsulation. Note that this option
+	// therefore is optional.
+	LabelSelector string
 }
 
 type CertOperatorPSP struct {
@@ -30,9 +38,6 @@ type CertOperatorVault struct {
 }
 
 func NewCertOperator(config CertOperatorConfig) (string, error) {
-	if config.ClusterName == "" {
-		return "", microerror.Maskf(invalidConfigError, "%T.ClusterName must not be empty", config)
-	}
 	if config.ClusterRole.BindingName == "" {
 		config.ClusterRole.BindingName = "cert-operator"
 	}

--- a/pkg/chartvalues/cert_operator_template.go
+++ b/pkg/chartvalues/cert_operator_template.go
@@ -15,7 +15,7 @@ Installation:
     GiantSwarm:
       CertOperator:
         CRD:
-          LabelSelector: 'giantswarm.io/cluster={{ .ClusterName }}'
+          LabelSelector: {{ .CRD.LabelSelector }}
     Guest:
       Kubernetes:
         API:

--- a/pkg/chartvalues/cert_operator_test.go
+++ b/pkg/chartvalues/cert_operator_test.go
@@ -8,16 +8,18 @@ import (
 
 func newCertOperatorConfigFromFilled(modifyFunc func(*CertOperatorConfig)) CertOperatorConfig {
 	c := CertOperatorConfig{
-		ClusterName: "test-cluster",
-		ClusterRole: CertOperatorClusterRole{
+		ClusterRole: CertOperatorConfigClusterRole{
 			BindingName: "test-cert-operator",
 			Name:        "test-cert-operator",
 		},
-		ClusterRolePSP: CertOperatorClusterRole{
+		ClusterRolePSP: CertOperatorConfigClusterRole{
 			BindingName: "test-cert-operator-psp",
 			Name:        "test-cert-operator-psp",
 		},
-		CommonDomain:       "test-common-domain",
+		CommonDomain: "test-common-domain",
+		CRD: CertOperatorConfigCRD{
+			LabelSelector: "test-label-selector",
+		},
 		Namespace:          "test-namespace",
 		RegistryPullSecret: "test-registry-pull-secret",
 		PSP: CertOperatorPSP{
@@ -64,7 +66,7 @@ Installation:
     GiantSwarm:
       CertOperator:
         CRD:
-          LabelSelector: 'giantswarm.io/cluster=test-cluster'
+          LabelSelector: test-label-selector
     Guest:
       Kubernetes:
         API:
@@ -87,7 +89,6 @@ pspName: test-cert-operator-psp
 		{
 			name: "case 2: non-default values set",
 			config: CertOperatorConfig{
-				ClusterName:        "test-cluster",
 				CommonDomain:       "test-common-domain",
 				RegistryPullSecret: "test-registry-pull-secret",
 				Vault: CertOperatorVault{
@@ -109,7 +110,7 @@ Installation:
     GiantSwarm:
       CertOperator:
         CRD:
-          LabelSelector: 'giantswarm.io/cluster=test-cluster'
+          LabelSelector:
     Guest:
       Kubernetes:
         API:
@@ -164,28 +165,21 @@ func Test_NewCertOperator_invalidConfigError(t *testing.T) {
 		errorMatcher func(err error) bool
 	}{
 		{
-			name: "case 0: invalid .ClusterName",
-			config: newCertOperatorConfigFromFilled(func(v *CertOperatorConfig) {
-				v.ClusterName = ""
-			}),
-			errorMatcher: IsInvalidConfig,
-		},
-		{
-			name: "case 1: invalid .CommonDomain",
+			name: "case 0: invalid .CommonDomain",
 			config: newCertOperatorConfigFromFilled(func(v *CertOperatorConfig) {
 				v.CommonDomain = ""
 			}),
 			errorMatcher: IsInvalidConfig,
 		},
 		{
-			name: "case 2: invalid .RegistryPullSecret",
+			name: "case 1: invalid .RegistryPullSecret",
 			config: newCertOperatorConfigFromFilled(func(v *CertOperatorConfig) {
 				v.RegistryPullSecret = ""
 			}),
 			errorMatcher: IsInvalidConfig,
 		},
 		{
-			name: "case 3: invalid .Vault.Token",
+			name: "case 2: invalid .Vault.Token",
 			config: newCertOperatorConfigFromFilled(func(v *CertOperatorConfig) {
 				v.Vault.Token = ""
 			}),


### PR DESCRIPTION
The label selector is actually optional and was only introduced for `kvm-operator` e2e tests. Its usage breaks now with the IPAM e2e tests in the `aws-operator` because the `cert-operator` within this setup does not watch for the test specific `CertConfig` CRs at all. 