### PR TITLE
Add AvailabilityZones for e2e

### DIFF
--- a/pkg/chartvalues/aws_operator_template.go
+++ b/pkg/chartvalues/aws_operator_template.go
@@ -27,6 +27,7 @@ const awsOperatorTemplate = `Installation:
     Name: ci-aws-operator
     Provider:
       AWS:
+        AvailabilityZones: '[eu-central-1a eu-central-1b eu-central-1c]'
         Region: '{{ .Provider.AWS.Region }}'
         DeleteLoggingBucket: true
         IncludeTags: true

--- a/pkg/chartvalues/aws_operator_test.go
+++ b/pkg/chartvalues/aws_operator_test.go
@@ -89,6 +89,7 @@ func Test_NewAWSOperator(t *testing.T) {
     Name: ci-aws-operator
     Provider:
       AWS:
+        AvailabilityZones: '[eu-central-1a eu-central-1b eu-central-1c]'
         Region: 'eu-central-1'
         DeleteLoggingBucket: true
         IncludeTags: true
@@ -160,6 +161,7 @@ func Test_NewAWSOperator(t *testing.T) {
     Name: ci-aws-operator
     Provider:
       AWS:
+        AvailabilityZones: '[eu-central-1a eu-central-1b eu-central-1c]'
         Region: 'eu-central-1'
         DeleteLoggingBucket: true
         IncludeTags: true


### PR DESCRIPTION
E2E is currently breaking because the value is empty in our e2e tests. This should atleast fix the test and eu-central-1 should be correct for gauss/ginger.