### PR TITLE
improves host peer stack template to not use env vars

### DIFF
--- a/pkg/e2etemplates/aws_host_peer_stack.go
+++ b/pkg/e2etemplates/aws_host_peer_stack.go
@@ -1,0 +1,45 @@
+package e2etemplates
+
+import (
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/e2etemplates/internal/render"
+)
+
+type AWSHostPeerStackConfig struct {
+	Stack       AWSHostPeerStackConfigStack
+	RouteTable0 AWSHostPeerStackConfigRouteTable0
+	RouteTable1 AWSHostPeerStackConfigRouteTable1
+}
+
+type AWSHostPeerStackConfigStack struct {
+	Name string
+}
+
+type AWSHostPeerStackConfigRouteTable0 struct {
+	Name string
+}
+
+type AWSHostPeerStackConfigRouteTable1 struct {
+	Name string
+}
+
+// NewAWSHostPeerStack renders awsHostPeerStackTemplate.
+func NewAWSHostPeerStack(config AWSHostPeerStackConfig) (string, error) {
+	if config.Stack.Name == "" {
+		return "", microerror.Maskf(invalidConfigError, "%T.Stack.Name must not be empty", config)
+	}
+	if config.RouteTable0.Name == "" {
+		return "", microerror.Maskf(invalidConfigError, "%T.RouteTable0.Name must not be empty", config)
+	}
+	if config.RouteTable1.Name == "" {
+		return "", microerror.Maskf(invalidConfigError, "%T.RouteTable1.Name must not be empty", config)
+	}
+
+	template, err := render.Render(awsHostPeerStackTemplate, config)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	return template, nil
+}

--- a/pkg/e2etemplates/aws_host_peer_stack_template.go
+++ b/pkg/e2etemplates/aws_host_peer_stack_template.go
@@ -1,8 +1,8 @@
 package e2etemplates
 
-// AWSHostVPCStack is deprecated. See awsHostPeerStackTemplate instead.
-const AWSHostVPCStack = `AWSTemplateFormatVersion: 2010-09-09
-Description: CI Host Stack with Peering VPC and route tables
+const awsHostPeerStackTemplate = `
+AWSTemplateFormatVersion: 2010-09-09
+Description: Host Peer Stack with VPC peering and route tables for testing purposes
 Resources:
   VPC:
     Type: AWS::EC2::VPC
@@ -10,24 +10,23 @@ Resources:
       CidrBlock: 10.11.0.0/16
       Tags:
       - Key: Name
-        Value: ${CLUSTER_NAME}
+        Value: {{ .Stack.Name }}
   PeerRouteTable0:
     Type: AWS::EC2::RouteTable
     Properties:
       VpcId: !Ref VPC
       Tags:
       - Key: Name
-        Value: ${AWS_ROUTE_TABLE_0}
+        Value: {{ .RouteTable0.Name }}
   PeerRouteTable1:
     Type: AWS::EC2::RouteTable
     Properties:
       VpcId: !Ref VPC
       Tags:
       - Key: Name
-        Value: ${AWS_ROUTE_TABLE_1}
+        Value: {{ .RouteTable1.Name }}
 Outputs:
   VPCID:
     Description: Accepter VPC ID
     Value: !Ref VPC
-
 `

--- a/pkg/e2etemplates/aws_host_peer_stack_test.go
+++ b/pkg/e2etemplates/aws_host_peer_stack_test.go
@@ -1,0 +1,153 @@
+package e2etemplates
+
+import (
+	"testing"
+
+	"github.com/giantswarm/e2etemplates/internal/rendertest"
+)
+
+func newAWSHostPeerStackConfigFromFilled(modifyFunc func(*AWSHostPeerStackConfig)) AWSHostPeerStackConfig {
+	c := AWSHostPeerStackConfig{
+		Stack: AWSHostPeerStackConfigStack{
+			Name: "test-stack-name",
+		},
+		RouteTable0: AWSHostPeerStackConfigRouteTable0{
+			Name: "test-route-table-0-name",
+		},
+		RouteTable1: AWSHostPeerStackConfigRouteTable1{
+			Name: "test-route-table-1-name",
+		},
+	}
+
+	modifyFunc(&c)
+
+	return c
+}
+
+func Test_NewAWSHostPeerStack(t *testing.T) {
+	testCases := []struct {
+		name           string
+		config         AWSHostPeerStackConfig
+		expectedValues string
+		errorMatcher   func(err error) bool
+	}{
+		{
+			name:           "case 0: invalid config",
+			config:         AWSHostPeerStackConfig{},
+			expectedValues: "",
+			errorMatcher:   IsInvalidConfig,
+		},
+		{
+			name:   "case 1: all values set",
+			config: newAWSHostPeerStackConfigFromFilled(func(v *AWSHostPeerStackConfig) {}),
+			expectedValues: `
+AWSTemplateFormatVersion: 2010-09-09
+Description: Host Peer Stack with VPC peering and route tables for testing purposes
+Resources:
+  VPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: 10.11.0.0/16
+      Tags:
+      - Key: Name
+        Value: test-stack-name
+  PeerRouteTable0:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+      Tags:
+      - Key: Name
+        Value: test-route-table-0-name
+  PeerRouteTable1:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+      Tags:
+      - Key: Name
+        Value: test-route-table-1-name
+Outputs:
+  VPCID:
+    Description: Accepter VPC ID
+    Value: !Ref VPC
+`,
+			errorMatcher: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			values, err := NewAWSHostPeerStack(tc.config)
+
+			switch {
+			case err == nil && tc.errorMatcher == nil:
+				// correct; carry on
+			case err != nil && tc.errorMatcher == nil:
+				t.Fatalf("error == %#v, want nil", err)
+			case err == nil && tc.errorMatcher != nil:
+				t.Fatalf("error == nil, want non-nil")
+			case !tc.errorMatcher(err):
+				t.Fatalf("error == %#v, want matching", err)
+			}
+
+			if tc.errorMatcher != nil {
+				return
+			}
+
+			line, difference := rendertest.Diff(values, tc.expectedValues)
+			if line > 0 {
+				t.Fatalf("line == %d, want 0, diff: %s", line, difference)
+			}
+		})
+	}
+}
+
+func Test_NewAWSHostPeerStack_invalidConfigError(t *testing.T) {
+	testCases := []struct {
+		name         string
+		config       AWSHostPeerStackConfig
+		errorMatcher func(err error) bool
+	}{
+		{
+			name: "case 0: invalid .Stack.Name",
+			config: newAWSHostPeerStackConfigFromFilled(func(v *AWSHostPeerStackConfig) {
+				v.Stack.Name = ""
+			}),
+			errorMatcher: IsInvalidConfig,
+		},
+		{
+			name: "case 1: invalid .RouteTable0.Name",
+			config: newAWSHostPeerStackConfigFromFilled(func(v *AWSHostPeerStackConfig) {
+				v.RouteTable0.Name = ""
+			}),
+			errorMatcher: IsInvalidConfig,
+		},
+		{
+			name: "case 1: invalid .RouteTable1.Name",
+			config: newAWSHostPeerStackConfigFromFilled(func(v *AWSHostPeerStackConfig) {
+				v.RouteTable1.Name = ""
+			}),
+			errorMatcher: IsInvalidConfig,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewAWSHostPeerStack(tc.config)
+
+			switch {
+			case err == nil && tc.errorMatcher == nil:
+				// correct; carry on
+			case err != nil && tc.errorMatcher == nil:
+				t.Fatalf("error == %#v, want nil", err)
+			case err == nil && tc.errorMatcher != nil:
+				t.Fatalf("error == nil, want non-nil")
+			case !tc.errorMatcher(err):
+				t.Fatalf("error == %#v, want matching", err)
+			}
+
+			if tc.errorMatcher != nil {
+				return
+			}
+		})
+	}
+}

--- a/pkg/e2etemplates/aws_host_vpc_stack.go
+++ b/pkg/e2etemplates/aws_host_vpc_stack.go
@@ -1,6 +1,10 @@
 package e2etemplates
 
-// AWSHostVPCStack is deprecated. See awsHostPeerStackTemplate instead.
+// TODO AWSHostVPCStack is deprecated. See awsHostPeerStackTemplate instead. We
+// track the cleanup in a roadmap story.
+//
+//     https://github.com/giantswarm/giantswarm/pull/2202
+//
 const AWSHostVPCStack = `AWSTemplateFormatVersion: 2010-09-09
 Description: CI Host Stack with Peering VPC and route tables
 Resources:

--- a/pkg/e2etemplates/error.go
+++ b/pkg/e2etemplates/error.go
@@ -1,0 +1,12 @@
+package e2etemplates
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}


### PR DESCRIPTION
We want to further cleanup any usage of env vars in templates. This here addresses certain changes in the template used to create host peer stacks in AWS e2e tests. See also https://github.com/giantswarm/giantswarm/pull/2202.