### PR TITLE
makes CIDRs configurable

### DIFF
--- a/pkg/chartvalues/apiextensions_aws_config_e2e.go
+++ b/pkg/chartvalues/apiextensions_aws_config_e2e.go
@@ -18,13 +18,19 @@ type APIExtensionsAWSConfigE2EConfig struct {
 type APIExtensionsAWSConfigE2EConfigAWS struct {
 	APIHostedZone     string
 	IngressHostedZone string
-	NetworkCIDR       string
+	// NetworkCIDR is deprecated and optional meanwhile. When left empty IPAM is
+	// activated.
+	NetworkCIDR string
+	// PrivateSubnetCIDR is deprecated and optional meanwhile. When left empty
+	// IPAM is activated.
 	PrivateSubnetCIDR string
-	PublicSubnetCIDR  string
-	Region            string
-	RouteTable0       string
-	RouteTable1       string
-	VPCPeerID         string
+	// PublicSubnetCIDR is deprecated and optional meanwhile. When left empty IPAM
+	// is activated.
+	PublicSubnetCIDR string
+	Region           string
+	RouteTable0      string
+	RouteTable1      string
+	VPCPeerID        string
 }
 
 // NewAPIExtensionsAWSConfigE2E renders values required by apiextensions-aws-config-e2e-chart.
@@ -46,15 +52,6 @@ func NewAPIExtensionsAWSConfigE2E(config APIExtensionsAWSConfigE2EConfig) (strin
 	}
 	if config.AWS.IngressHostedZone == "" {
 		return "", microerror.Maskf(invalidConfigError, "%T.AWS.IngressHostedZone must not be empty", config)
-	}
-	if config.AWS.NetworkCIDR == "" {
-		return "", microerror.Maskf(invalidConfigError, "%T.AWS.NetworkCIDR must not be empty", config)
-	}
-	if config.AWS.PrivateSubnetCIDR == "" {
-		return "", microerror.Maskf(invalidConfigError, "%T.AWS.PrivateSubnetCIDR must not be empty", config)
-	}
-	if config.AWS.PublicSubnetCIDR == "" {
-		return "", microerror.Maskf(invalidConfigError, "%T.AWS.PublicSubnetCIDR must not be empty", config)
 	}
 	if config.AWS.Region == "" {
 		return "", microerror.Maskf(invalidConfigError, "%T.AWS.Region must not be empty", config)

--- a/pkg/chartvalues/apiextensions_aws_config_e2e.go
+++ b/pkg/chartvalues/apiextensions_aws_config_e2e.go
@@ -16,9 +16,12 @@ type APIExtensionsAWSConfigE2EConfig struct {
 }
 
 type APIExtensionsAWSConfigE2EConfigAWS struct {
-	Region            string
 	APIHostedZone     string
 	IngressHostedZone string
+	NetworkCIDR       string
+	PrivateSubnetCIDR string
+	PublicSubnetCIDR  string
+	Region            string
 	RouteTable0       string
 	RouteTable1       string
 	VPCPeerID         string
@@ -38,14 +41,23 @@ func NewAPIExtensionsAWSConfigE2E(config APIExtensionsAWSConfigE2EConfig) (strin
 	if config.VersionBundleVersion == "" {
 		return "", microerror.Maskf(invalidConfigError, "%T.VersionBundleVersion must not be empty", config)
 	}
-	if config.AWS.Region == "" {
-		return "", microerror.Maskf(invalidConfigError, "%T.AWS.Region must not be empty", config)
-	}
 	if config.AWS.APIHostedZone == "" {
 		return "", microerror.Maskf(invalidConfigError, "%T.AWS.APIHostedZone must not be empty", config)
 	}
 	if config.AWS.IngressHostedZone == "" {
 		return "", microerror.Maskf(invalidConfigError, "%T.AWS.IngressHostedZone must not be empty", config)
+	}
+	if config.AWS.NetworkCIDR == "" {
+		return "", microerror.Maskf(invalidConfigError, "%T.AWS.NetworkCIDR must not be empty", config)
+	}
+	if config.AWS.PrivateSubnetCIDR == "" {
+		return "", microerror.Maskf(invalidConfigError, "%T.AWS.PrivateSubnetCIDR must not be empty", config)
+	}
+	if config.AWS.PublicSubnetCIDR == "" {
+		return "", microerror.Maskf(invalidConfigError, "%T.AWS.PublicSubnetCIDR must not be empty", config)
+	}
+	if config.AWS.Region == "" {
+		return "", microerror.Maskf(invalidConfigError, "%T.AWS.Region must not be empty", config)
 	}
 	if config.AWS.RouteTable0 == "" {
 		return "", microerror.Maskf(invalidConfigError, "%T.AWS.RouteTable0 must not be empty", config)

--- a/pkg/chartvalues/apiextensions_aws_config_e2e_template.go
+++ b/pkg/chartvalues/apiextensions_aws_config_e2e_template.go
@@ -6,9 +6,9 @@ clusterVersion: v_0_1_0
 sshPublicKey: {{ .SSHPublicKey }}
 versionBundleVersion: {{ .VersionBundleVersion }}
 aws:
-  networkCIDR: "10.12.0.0/24"
-  privateSubnetCIDR: "10.12.0.0/25"
-  publicSubnetCIDR: "10.12.0.128/25"
+  networkCIDR: {{ .AWS.NetworkCIDR }}
+  privateSubnetCIDR: {{ .AWS.PrivateSubnetCIDR }}
+  publicSubnetCIDR: {{ .AWS.PublicSubnetCIDR }}
   region: {{ .AWS.Region }}
   apiHostedZone: {{ .AWS.APIHostedZone }}
   ingressHostedZone: {{ .AWS.IngressHostedZone }}

--- a/pkg/chartvalues/apiextensions_aws_config_e2e_test.go
+++ b/pkg/chartvalues/apiextensions_aws_config_e2e_test.go
@@ -67,7 +67,9 @@ aws:
 		{
 			name: "case 2: all optional values left",
 			config: newAPIExtensionsAWSConfigE2EConfigFromFilled(func(v *APIExtensionsAWSConfigE2EConfig) {
-				// Placeholder. No default values for this template yet.
+				v.AWS.NetworkCIDR = ""
+				v.AWS.PrivateSubnetCIDR = ""
+				v.AWS.PublicSubnetCIDR = ""
 			}),
 			expectedValues: `commonDomain: test-common-domain
 clusterName: test-cluster-name
@@ -75,9 +77,9 @@ clusterVersion: v_0_1_0
 sshPublicKey: test-ssh-public-key
 versionBundleVersion: test-version-bundle-version
 aws:
-  networkCIDR: test-network-cidr
-  privateSubnetCIDR: test-private-subnet-cidr
-  publicSubnetCIDR: test-public-subnet-cidr
+  networkCIDR:
+  privateSubnetCIDR:
+  publicSubnetCIDR:
   region: test-region
   apiHostedZone: test-api-hosted-zone
   ingressHostedZone: test-ingress-hosted-zone
@@ -165,49 +167,28 @@ func Test_NewAPIExtensionsAWSConfigE2E_invalidConfigError(t *testing.T) {
 			errorMatcher: IsInvalidConfig,
 		},
 		{
-			name: "case 6: invalid .AWS.NetworkCIDR",
-			config: newAPIExtensionsAWSConfigE2EConfigFromFilled(func(v *APIExtensionsAWSConfigE2EConfig) {
-				v.AWS.NetworkCIDR = ""
-			}),
-			errorMatcher: IsInvalidConfig,
-		},
-		{
-			name: "case 7: invalid .AWS.PrivateSubnetCIDR",
-			config: newAPIExtensionsAWSConfigE2EConfigFromFilled(func(v *APIExtensionsAWSConfigE2EConfig) {
-				v.AWS.PrivateSubnetCIDR = ""
-			}),
-			errorMatcher: IsInvalidConfig,
-		},
-		{
-			name: "case 8: invalid .AWS.PublicSubnetCIDR",
-			config: newAPIExtensionsAWSConfigE2EConfigFromFilled(func(v *APIExtensionsAWSConfigE2EConfig) {
-				v.AWS.PublicSubnetCIDR = ""
-			}),
-			errorMatcher: IsInvalidConfig,
-		},
-		{
-			name: "case 9: invalid .AWS.Region",
+			name: "case 6: invalid .AWS.Region",
 			config: newAPIExtensionsAWSConfigE2EConfigFromFilled(func(v *APIExtensionsAWSConfigE2EConfig) {
 				v.AWS.Region = ""
 			}),
 			errorMatcher: IsInvalidConfig,
 		},
 		{
-			name: "case 10: invalid .AWS.RouteTable0",
+			name: "case 7: invalid .AWS.RouteTable0",
 			config: newAPIExtensionsAWSConfigE2EConfigFromFilled(func(v *APIExtensionsAWSConfigE2EConfig) {
 				v.AWS.RouteTable0 = ""
 			}),
 			errorMatcher: IsInvalidConfig,
 		},
 		{
-			name: "case 11: invalid .AWS.RouteTable1",
+			name: "case 8: invalid .AWS.RouteTable1",
 			config: newAPIExtensionsAWSConfigE2EConfigFromFilled(func(v *APIExtensionsAWSConfigE2EConfig) {
 				v.AWS.RouteTable1 = ""
 			}),
 			errorMatcher: IsInvalidConfig,
 		},
 		{
-			name: "case 12: invalid .AWS.VPCPeerID",
+			name: "case 9: invalid .AWS.VPCPeerID",
 			config: newAPIExtensionsAWSConfigE2EConfigFromFilled(func(v *APIExtensionsAWSConfigE2EConfig) {
 				v.AWS.VPCPeerID = ""
 			}),

--- a/pkg/chartvalues/apiextensions_aws_config_e2e_test.go
+++ b/pkg/chartvalues/apiextensions_aws_config_e2e_test.go
@@ -14,9 +14,12 @@ func newAPIExtensionsAWSConfigE2EConfigFromFilled(modifyFunc func(*APIExtensions
 		VersionBundleVersion: "test-version-bundle-version",
 
 		AWS: APIExtensionsAWSConfigE2EConfigAWS{
-			Region:            "test-region",
 			APIHostedZone:     "test-api-hosted-zone",
 			IngressHostedZone: "test-ingress-hosted-zone",
+			NetworkCIDR:       "test-network-cidr",
+			PrivateSubnetCIDR: "test-private-subnet-cidr",
+			PublicSubnetCIDR:  "test-public-subnet-cidr",
+			Region:            "test-region",
 			RouteTable0:       "test-route-table-0",
 			RouteTable1:       "test-route-table-1",
 			VPCPeerID:         "test-vpc-peer-id",
@@ -49,9 +52,9 @@ clusterVersion: v_0_1_0
 sshPublicKey: test-ssh-public-key
 versionBundleVersion: test-version-bundle-version
 aws:
-  networkCIDR: "10.12.0.0/24"
-  privateSubnetCIDR: "10.12.0.0/25"
-  publicSubnetCIDR: "10.12.0.128/25"
+  networkCIDR: test-network-cidr
+  privateSubnetCIDR: test-private-subnet-cidr
+  publicSubnetCIDR: test-public-subnet-cidr
   region: test-region
   apiHostedZone: test-api-hosted-zone
   ingressHostedZone: test-ingress-hosted-zone
@@ -72,9 +75,9 @@ clusterVersion: v_0_1_0
 sshPublicKey: test-ssh-public-key
 versionBundleVersion: test-version-bundle-version
 aws:
-  networkCIDR: "10.12.0.0/24"
-  privateSubnetCIDR: "10.12.0.0/25"
-  publicSubnetCIDR: "10.12.0.128/25"
+  networkCIDR: test-network-cidr
+  privateSubnetCIDR: test-private-subnet-cidr
+  publicSubnetCIDR: test-public-subnet-cidr
   region: test-region
   apiHostedZone: test-api-hosted-zone
   ingressHostedZone: test-ingress-hosted-zone
@@ -148,42 +151,63 @@ func Test_NewAPIExtensionsAWSConfigE2E_invalidConfigError(t *testing.T) {
 			errorMatcher: IsInvalidConfig,
 		},
 		{
-			name: "case 4: invalid .AWS.Region",
-			config: newAPIExtensionsAWSConfigE2EConfigFromFilled(func(v *APIExtensionsAWSConfigE2EConfig) {
-				v.AWS.Region = ""
-			}),
-			errorMatcher: IsInvalidConfig,
-		},
-		{
-			name: "case 5: invalid .AWS.APIHostedZone",
+			name: "case 4: invalid .AWS.APIHostedZone",
 			config: newAPIExtensionsAWSConfigE2EConfigFromFilled(func(v *APIExtensionsAWSConfigE2EConfig) {
 				v.AWS.APIHostedZone = ""
 			}),
 			errorMatcher: IsInvalidConfig,
 		},
 		{
-			name: "case 6: invalid .AWS.IngressHostedZone",
+			name: "case 5: invalid .AWS.IngressHostedZone",
 			config: newAPIExtensionsAWSConfigE2EConfigFromFilled(func(v *APIExtensionsAWSConfigE2EConfig) {
 				v.AWS.IngressHostedZone = ""
 			}),
 			errorMatcher: IsInvalidConfig,
 		},
 		{
-			name: "case 7: invalid .AWS.RouteTable0",
+			name: "case 6: invalid .AWS.NetworkCIDR",
+			config: newAPIExtensionsAWSConfigE2EConfigFromFilled(func(v *APIExtensionsAWSConfigE2EConfig) {
+				v.AWS.NetworkCIDR = ""
+			}),
+			errorMatcher: IsInvalidConfig,
+		},
+		{
+			name: "case 7: invalid .AWS.PrivateSubnetCIDR",
+			config: newAPIExtensionsAWSConfigE2EConfigFromFilled(func(v *APIExtensionsAWSConfigE2EConfig) {
+				v.AWS.PrivateSubnetCIDR = ""
+			}),
+			errorMatcher: IsInvalidConfig,
+		},
+		{
+			name: "case 8: invalid .AWS.PublicSubnetCIDR",
+			config: newAPIExtensionsAWSConfigE2EConfigFromFilled(func(v *APIExtensionsAWSConfigE2EConfig) {
+				v.AWS.PublicSubnetCIDR = ""
+			}),
+			errorMatcher: IsInvalidConfig,
+		},
+		{
+			name: "case 9: invalid .AWS.Region",
+			config: newAPIExtensionsAWSConfigE2EConfigFromFilled(func(v *APIExtensionsAWSConfigE2EConfig) {
+				v.AWS.Region = ""
+			}),
+			errorMatcher: IsInvalidConfig,
+		},
+		{
+			name: "case 10: invalid .AWS.RouteTable0",
 			config: newAPIExtensionsAWSConfigE2EConfigFromFilled(func(v *APIExtensionsAWSConfigE2EConfig) {
 				v.AWS.RouteTable0 = ""
 			}),
 			errorMatcher: IsInvalidConfig,
 		},
 		{
-			name: "case 8: invalid .AWS.RouteTable1",
+			name: "case 11: invalid .AWS.RouteTable1",
 			config: newAPIExtensionsAWSConfigE2EConfigFromFilled(func(v *APIExtensionsAWSConfigE2EConfig) {
 				v.AWS.RouteTable1 = ""
 			}),
 			errorMatcher: IsInvalidConfig,
 		},
 		{
-			name: "case 9: invalid .AWS.VPCPeerID",
+			name: "case 12: invalid .AWS.VPCPeerID",
 			config: newAPIExtensionsAWSConfigE2EConfigFromFilled(func(v *APIExtensionsAWSConfigE2EConfig) {
 				v.AWS.VPCPeerID = ""
 			}),


### PR DESCRIPTION
In order to IPAM e2e tests work we need to configure network more properly for the tenant clusters. Testing this in https://github.com/giantswarm/aws-operator/pull/1248. 