### PR TITLE
Fix tabs to spaces

### DIFF
--- a/pkg/chartvalues/aws_operator_template.go
+++ b/pkg/chartvalues/aws_operator_template.go
@@ -28,9 +28,9 @@ const awsOperatorTemplate = `Installation:
     Provider:
       AWS:
         AvailabilityZones:
-		  - eu-central-1a
-		  - eu-central-1b
-		  - eu-central-1c
+          - eu-central-1a
+          - eu-central-1b
+          - eu-central-1c
         Region: '{{ .Provider.AWS.Region }}'
         DeleteLoggingBucket: true
         IncludeTags: true

--- a/pkg/chartvalues/aws_operator_test.go
+++ b/pkg/chartvalues/aws_operator_test.go
@@ -90,9 +90,9 @@ func Test_NewAWSOperator(t *testing.T) {
     Provider:
       AWS:
         AvailabilityZones:
-		  - eu-central-1a
-		  - eu-central-1b
-		  - eu-central-1c
+          - eu-central-1a
+          - eu-central-1b
+          - eu-central-1c
         Region: 'eu-central-1'
         DeleteLoggingBucket: true
         IncludeTags: true
@@ -165,9 +165,9 @@ func Test_NewAWSOperator(t *testing.T) {
     Provider:
       AWS:
         AvailabilityZones:
-		  - eu-central-1a
-		  - eu-central-1b
-		  - eu-central-1c
+          - eu-central-1a
+          - eu-central-1b
+          - eu-central-1c
         Region: 'eu-central-1'
         DeleteLoggingBucket: true
         IncludeTags: true


### PR DESCRIPTION
My editor used tabs instead of space so yaml was incorrect.

...it's hard occasionally. Maybe now...