### PR TITLE
Set defaults for CIDR for old versions

### DIFF
--- a/pkg/chartvalues/apiextensions_aws_config_e2e.go
+++ b/pkg/chartvalues/apiextensions_aws_config_e2e.go
@@ -19,13 +19,13 @@ type APIExtensionsAWSConfigE2EConfigAWS struct {
 	APIHostedZone     string
 	IngressHostedZone string
 	// NetworkCIDR is deprecated and optional meanwhile. When left empty IPAM is
-	// activated.
+	// activated. We still need defaults for older versions.
 	NetworkCIDR string
 	// PrivateSubnetCIDR is deprecated and optional meanwhile. When left empty
-	// IPAM is activated.
+	// IPAM is activated. We still need defaults for older versions.
 	PrivateSubnetCIDR string
 	// PublicSubnetCIDR is deprecated and optional meanwhile. When left empty IPAM
-	// is activated.
+	// is activated. We still need defaults for older versions.
 	PublicSubnetCIDR string
 	Region           string
 	RouteTable0      string

--- a/pkg/chartvalues/apiextensions_aws_config_e2e.go
+++ b/pkg/chartvalues/apiextensions_aws_config_e2e.go
@@ -53,6 +53,15 @@ func NewAPIExtensionsAWSConfigE2E(config APIExtensionsAWSConfigE2EConfig) (strin
 	if config.AWS.IngressHostedZone == "" {
 		return "", microerror.Maskf(invalidConfigError, "%T.AWS.IngressHostedZone must not be empty", config)
 	}
+	if config.AWS.NetworkCIDR == "" {
+		config.AWS.NetworkCIDR = "10.12.0.0/24"
+	}
+	if config.AWS.PrivateSubnetCIDR == "" {
+		config.AWS.PrivateSubnetCIDR = "10.12.0.0/25"
+	}
+	if config.AWS.PublicSubnetCIDR == "" {
+		config.AWS.PublicSubnetCIDR = "10.12.0.128/25"
+	}
 	if config.AWS.Region == "" {
 		return "", microerror.Maskf(invalidConfigError, "%T.AWS.Region must not be empty", config)
 	}

--- a/pkg/chartvalues/apiextensions_aws_config_e2e_test.go
+++ b/pkg/chartvalues/apiextensions_aws_config_e2e_test.go
@@ -77,9 +77,9 @@ clusterVersion: v_0_1_0
 sshPublicKey: test-ssh-public-key
 versionBundleVersion: test-version-bundle-version
 aws:
-  networkCIDR:
-  privateSubnetCIDR:
-  publicSubnetCIDR:
+  networkCIDR: 10.12.0.0/24
+  privateSubnetCIDR: 10.12.0.0/25
+  publicSubnetCIDR: 10.12.0.128/25
   region: test-region
   apiHostedZone: test-api-hosted-zone
   ingressHostedZone: test-ingress-hosted-zone


### PR DESCRIPTION
Currently v18 tests in our multi-AZ branch fail because that is still the current version:
https://circleci.com/gh/giantswarm/aws-operator/15016?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

This puts back the defaults that should be needed to get our tests green.