### PR TITLE
Remove quote for bool type

### DIFF
--- a/pkg/chartvalues/apiextensions_app_e2e_template.go
+++ b/pkg/chartvalues/apiextensions_app_e2e_template.go
@@ -13,7 +13,7 @@ app:
       name: "{{ .App.Config.Secret.Name }}"
       namespace: "{{ .App.Config.Secret.Namespace }}"
   kubeConfig:
-    inCluster: "{{ .App.KubeConfig.InCluster }}"
+    inCluster: {{ .App.KubeConfig.InCluster }}
     secret:
       name: "{{ .App.KubeConfig.Secret.Name }}"
       namespace: "{{ .App.KubeConfig.Secret.Namespace }}"

--- a/pkg/chartvalues/apiextensions_app_e2e_test.go
+++ b/pkg/chartvalues/apiextensions_app_e2e_test.go
@@ -87,7 +87,7 @@ app:
       name: "test-app-secrets"
       namespace: "default"
   kubeConfig:
-    inCluster: "false"
+    inCluster: false
     secret:
       name: "test-kubeconfig-secret"
       namespace: "default"


### PR DESCRIPTION
- To remove errors from deployment as below
```
E0226 16:11:16.349363       1 streamwatcher.go:109] Unable to decode an event from the watch stream: unable to decode watch event: v1alpha1.App.Spec: v1alpha1.AppSpec.KubeConfig: v1alpha1.AppSpecKubeConfig.InCluster: ReadBool: expect t or f, but found ", error found in #10 byte of ...|Cluster":"false","se|..., bigger context ...|e":"","namespace":""}},"kubeConfig":{"inCluster":"false","secret":{"name":"kubeconfig-secret","names|...
```