### PR TITLE
add route tables to aws-operator

### DIFF
--- a/pkg/chartvalues/aws_operator_template.go
+++ b/pkg/chartvalues/aws_operator_template.go
@@ -36,6 +36,7 @@ const awsOperatorTemplate = `Installation:
         IncludeTags: true
         Route53:
           Enabled: true
+        RouteTables: 'gauss_private_0,gauss_private_1'
         Encrypter: '{{ .Provider.AWS.Encrypter }}'
         TrustedAdvisor:
           Enabled: false

--- a/pkg/chartvalues/aws_operator_test.go
+++ b/pkg/chartvalues/aws_operator_test.go
@@ -98,6 +98,7 @@ func Test_NewAWSOperator(t *testing.T) {
         IncludeTags: true
         Route53:
           Enabled: true
+        RouteTables: 'gauss_private_0,gauss_private_1'
         Encrypter: 'vault'
         TrustedAdvisor:
           Enabled: false
@@ -173,6 +174,7 @@ func Test_NewAWSOperator(t *testing.T) {
         IncludeTags: true
         Route53:
           Enabled: true
+        RouteTables: 'gauss_private_0,gauss_private_1'
         Encrypter: 'kms'
         TrustedAdvisor:
           Enabled: false


### PR DESCRIPTION
The `aws-operator` fetches the route table IDs and caches them. We need the route table names to be configured though. The e2e tests are not properly aligned. So this PR fixes that. 