### PR TITLE
Add VPCPeerID as flag to aws-operator chart

### DIFF
--- a/pkg/chartvalues/aws_operator.go
+++ b/pkg/chartvalues/aws_operator.go
@@ -33,7 +33,6 @@ type AWSOperatorConfigSecret struct {
 
 type AWSOperatorConfigSecretAWSOperator struct {
 	CredentialDefault AWSOperatorConfigSecretAWSOperatorCredentialDefault
-	IDRSAPub          string
 	SecretYaml        AWSOperatorConfigSecretAWSOperatorSecretYaml
 }
 
@@ -71,9 +70,6 @@ func NewAWSOperator(config AWSOperatorConfig) (string, error) {
 	}
 	if config.Provider.AWS.RouteTableNames == "" {
 		return "", microerror.Maskf(invalidConfigError, "%T.Provider.AWS.RouteTableNames must not be empty", config)
-	}
-	if config.Secret.AWSOperator.IDRSAPub == "" {
-		return "", microerror.Maskf(invalidConfigError, "%T.Secret.AWSOperator.IDRSAPub must not be empty", config)
 	}
 	if config.Secret.AWSOperator.CredentialDefault.AdminARN == "" {
 		return "", microerror.Maskf(invalidConfigError, "%T.Secret.AWSOperator.CredentialDefault.AdminARN must not be empty", config)

--- a/pkg/chartvalues/aws_operator.go
+++ b/pkg/chartvalues/aws_operator.go
@@ -25,6 +25,7 @@ type AWSOperatorConfigProviderAWS struct {
 	Encrypter       string
 	Region          string
 	RouteTableNames string
+	VPCPeerID       string
 }
 
 type AWSOperatorConfigSecret struct {
@@ -70,6 +71,9 @@ func NewAWSOperator(config AWSOperatorConfig) (string, error) {
 	}
 	if config.Provider.AWS.RouteTableNames == "" {
 		return "", microerror.Maskf(invalidConfigError, "%T.Provider.AWS.RouteTableNames must not be empty", config)
+	}
+	if config.Provider.AWS.VPCPeerID == "" {
+		return "", microerror.Maskf(invalidConfigError, "%T.Provider.AWS.VPCPeerID must not be empty", config)
 	}
 	if config.Secret.AWSOperator.CredentialDefault.AdminARN == "" {
 		return "", microerror.Maskf(invalidConfigError, "%T.Secret.AWSOperator.CredentialDefault.AdminARN must not be empty", config)

--- a/pkg/chartvalues/aws_operator_template.go
+++ b/pkg/chartvalues/aws_operator_template.go
@@ -47,7 +47,6 @@ const awsOperatorTemplate = `Installation:
         CredentialDefault:
           AdminARN: '{{ .Secret.AWSOperator.CredentialDefault.AdminARN }}'
           AWSOperatorARN: '{{ .Secret.AWSOperator.CredentialDefault.AWSOperatorARN }}'
-        IDRSAPub: {{ .Secret.AWSOperator.IDRSAPub }}
         SecretYaml: |
           service:
             aws:

--- a/pkg/chartvalues/aws_operator_template.go
+++ b/pkg/chartvalues/aws_operator_template.go
@@ -40,6 +40,7 @@ const awsOperatorTemplate = `Installation:
         Encrypter: '{{ .Provider.AWS.Encrypter }}'
         TrustedAdvisor:
           Enabled: false
+        VPCPeerID: '{{ .Provider.AWS.VPCPeerID }}'
     Registry:
       Domain: quay.io
     Secret:

--- a/pkg/chartvalues/aws_operator_test.go
+++ b/pkg/chartvalues/aws_operator_test.go
@@ -277,28 +277,28 @@ func Test_NewAWSOperator_invalidConfigError(t *testing.T) {
 			errorMatcher: IsInvalidConfig,
 		},
 		{
-			name: "case 6: invalid .Secret.AWSOperator.SecretYaml.Service.AWS.AccessKey.Secret",
+			name: "case 5: invalid .Secret.AWSOperator.SecretYaml.Service.AWS.AccessKey.Secret",
 			config: newAWSOperatorConfigFromFilled(func(v *AWSOperatorConfig) {
 				v.Secret.AWSOperator.SecretYaml.Service.AWS.AccessKey.Secret = ""
 			}),
 			errorMatcher: IsInvalidConfig,
 		},
 		{
-			name: "case 7: invalid .Secret.AWSOperator.SecretYaml.Service.AWS.HostAccessKey.ID",
+			name: "case 6: invalid .Secret.AWSOperator.SecretYaml.Service.AWS.HostAccessKey.ID",
 			config: newAWSOperatorConfigFromFilled(func(v *AWSOperatorConfig) {
 				v.Secret.AWSOperator.SecretYaml.Service.AWS.HostAccessKey.ID = ""
 			}),
 			errorMatcher: IsInvalidConfig,
 		},
 		{
-			name: "case 8: invalid .Secret.AWSOperator.SecretYaml.Service.AWS.HostAccessKey.Secret",
+			name: "case 7: invalid .Secret.AWSOperator.SecretYaml.Service.AWS.HostAccessKey.Secret",
 			config: newAWSOperatorConfigFromFilled(func(v *AWSOperatorConfig) {
 				v.Secret.AWSOperator.SecretYaml.Service.AWS.HostAccessKey.Secret = ""
 			}),
 			errorMatcher: IsInvalidConfig,
 		},
 		{
-			name: "case 9: invalid .RegistryPullSecret",
+			name: "case 8: invalid .RegistryPullSecret",
 			config: newAWSOperatorConfigFromFilled(func(v *AWSOperatorConfig) {
 				v.RegistryPullSecret = ""
 			}),

--- a/pkg/chartvalues/aws_operator_test.go
+++ b/pkg/chartvalues/aws_operator_test.go
@@ -103,7 +103,7 @@ func Test_NewAWSOperator(t *testing.T) {
         Encrypter: 'vault'
         TrustedAdvisor:
           Enabled: false
-				VPCPeerID: 'test-vpc-id'
+        VPCPeerID: 'test-vpc-id'
     Registry:
       Domain: quay.io
     Secret:
@@ -179,7 +179,7 @@ func Test_NewAWSOperator(t *testing.T) {
         Encrypter: 'kms'
         TrustedAdvisor:
           Enabled: false
-				VPCPeerID: 'test-vpc-id'
+        VPCPeerID: 'test-vpc-id'
     Registry:
       Domain: quay.io
     Secret:

--- a/pkg/chartvalues/aws_operator_test.go
+++ b/pkg/chartvalues/aws_operator_test.go
@@ -13,6 +13,7 @@ func newAWSOperatorConfigFromFilled(modifyFunc func(*AWSOperatorConfig)) AWSOper
 				Encrypter:       "vault",
 				Region:          "eu-central-1",
 				RouteTableNames: "foo,bar",
+				VPCPeerID:       "test-vpc-id",
 			},
 		},
 		Secret: AWSOperatorConfigSecret{
@@ -102,6 +103,7 @@ func Test_NewAWSOperator(t *testing.T) {
         Encrypter: 'vault'
         TrustedAdvisor:
           Enabled: false
+				VPCPeerID: 'test-vpc-id'
     Registry:
       Domain: quay.io
     Secret:
@@ -177,6 +179,7 @@ func Test_NewAWSOperator(t *testing.T) {
         Encrypter: 'kms'
         TrustedAdvisor:
           Enabled: false
+				VPCPeerID: 'test-vpc-id'
     Registry:
       Domain: quay.io
     Secret:
@@ -301,6 +304,13 @@ func Test_NewAWSOperator_invalidConfigError(t *testing.T) {
 			name: "case 8: invalid .RegistryPullSecret",
 			config: newAWSOperatorConfigFromFilled(func(v *AWSOperatorConfig) {
 				v.RegistryPullSecret = ""
+			}),
+			errorMatcher: IsInvalidConfig,
+		},
+		{
+			name: "case 9: invalid .Provider.AWS.VPCPeerID",
+			config: newAWSOperatorConfigFromFilled(func(v *AWSOperatorConfig) {
+				v.Provider.AWS.VPCPeerID = ""
 			}),
 			errorMatcher: IsInvalidConfig,
 		},

--- a/pkg/chartvalues/aws_operator_test.go
+++ b/pkg/chartvalues/aws_operator_test.go
@@ -21,7 +21,6 @@ func newAWSOperatorConfigFromFilled(modifyFunc func(*AWSOperatorConfig)) AWSOper
 					AdminARN:       "test-admin-arn",
 					AWSOperatorARN: "test-awsoperator-arn",
 				},
-				IDRSAPub: "test-idrsa-pub",
 				SecretYaml: AWSOperatorConfigSecretAWSOperatorSecretYaml{
 					Service: AWSOperatorConfigSecretAWSOperatorSecretYamlService{
 						AWS: AWSOperatorConfigSecretAWSOperatorSecretYamlServiceAWS{
@@ -110,7 +109,6 @@ func Test_NewAWSOperator(t *testing.T) {
         CredentialDefault:
           AdminARN: 'test-admin-arn'
           AWSOperatorARN: 'test-awsoperator-arn'
-        IDRSAPub: test-idrsa-pub
         SecretYaml: |
           service:
             aws:
@@ -186,7 +184,6 @@ func Test_NewAWSOperator(t *testing.T) {
         CredentialDefault:
           AdminARN: 'test-admin-arn'
           AWSOperatorARN: 'test-awsoperator-arn'
-        IDRSAPub: test-idrsa-pub
         SecretYaml: |
           service:
             aws:
@@ -276,13 +273,6 @@ func Test_NewAWSOperator_invalidConfigError(t *testing.T) {
 			name: "case 4: invalid .Secret.AWSOperator.SecretYaml.Service.AWS.AccessKey.ID",
 			config: newAWSOperatorConfigFromFilled(func(v *AWSOperatorConfig) {
 				v.Secret.AWSOperator.SecretYaml.Service.AWS.AccessKey.ID = ""
-			}),
-			errorMatcher: IsInvalidConfig,
-		},
-		{
-			name: "case 5: invalid .Secret.AWSOperator.IDRSAPub",
-			config: newAWSOperatorConfigFromFilled(func(v *AWSOperatorConfig) {
-				v.Secret.AWSOperator.IDRSAPub = ""
 			}),
 			errorMatcher: IsInvalidConfig,
 		},


### PR DESCRIPTION
After changes by Tim we now pass the VPCPeerID directly to the operator through flags. 

Leaving the old way of configuration still here as old operator versions still use the CR.