### PR TITLE
add image pull deadline to aws-operator template

### DIFF
--- a/pkg/chartvalues/aws_operator_template.go
+++ b/pkg/chartvalues/aws_operator_template.go
@@ -26,6 +26,8 @@ const awsOperatorTemplate = `Installation:
                 UsernameClaim: ""
                 GroupsClaim: ""
           ClusterIPRange: "172.31.0.0/24"
+        Kubelet:
+          ImagePullProgressDeadline: 1m
       SSH:
         SSOPublicKey: 'test'
         UserList: '{{ .SSH.UserList }}'

--- a/pkg/chartvalues/aws_operator_test.go
+++ b/pkg/chartvalues/aws_operator_test.go
@@ -92,6 +92,8 @@ func Test_NewAWSOperator(t *testing.T) {
                 UsernameClaim: ""
                 GroupsClaim: ""
           ClusterIPRange: "172.31.0.0/24"
+        Kubelet:
+          ImagePullProgressDeadline: 1m
       SSH:
         SSOPublicKey: 'test'
         UserList: 'test-user-list'
@@ -174,6 +176,8 @@ func Test_NewAWSOperator(t *testing.T) {
                 UsernameClaim: ""
                 GroupsClaim: ""
           ClusterIPRange: "172.31.0.0/24"
+        Kubelet:
+          ImagePullProgressDeadline: 1m
       SSH:
         SSOPublicKey: 'test'
         UserList: 'test-user-list'


### PR DESCRIPTION
Fixes the following error from failed e2e test https://circleci.com/gh/giantswarm/aws-operator/22406: 

```
{
  "caller": "github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/helmclient/helmclient.go:354",
  "level": "debug",
  "message": "err string: `rpc error: code = Unknown desc = render error in \"aws-operator-chart/templates/configmap.yaml\": template: aws-operator-chart/templates/configmap.yaml:44:50: executing \"aws-operator-chart/templates/configmap.yaml\" at <.Values.Installation...>: can't evaluate field ImagePullProgressDeadline in type interface {}`",
  "time": "2019-08-08T14:54:59.14707+00:00"
}
```