### PR TITLE
Add chart-operator into e2e test

### DIFF
--- a/pkg/chartvalues/apiextensions_app_e2e_template.go
+++ b/pkg/chartvalues/apiextensions_app_e2e_template.go
@@ -1,42 +1,55 @@
 package chartvalues
 
 const apiExtensionsAppE2ETemplate = `
-app:
-  name: "{{ .App.Name }}"
-  namespace: "{{ .App.Namespace }}"
-  catalog: "{{ .App.Catalog }}"
-  config:
-    configMap:
-      name: "{{ .App.Config.ConfigMap.Name }}"
-      namespace: "{{ .App.Config.ConfigMap.Namespace }}"
-    secret:
-      name: "{{ .App.Config.Secret.Name }}"
-      namespace: "{{ .App.Config.Secret.Namespace }}"
-  kubeConfig:
-    inCluster: {{ .App.KubeConfig.InCluster }}
-    secret:
-      name: "{{ .App.KubeConfig.Secret.Name }}"
-      namespace: "{{ .App.KubeConfig.Secret.Namespace }}"
-  version: "{{ .App.Version }}"
+apps:
+  - name: "{{ .App.Name }}"
+    namespace: "{{ .App.Namespace }}"
+    catalog: "{{ .App.Catalog }}"
+    config:
+      configMap:
+        name: "{{ .App.Config.ConfigMap.Name }}"
+        namespace: "{{ .App.Config.ConfigMap.Namespace }}"
+      secret:
+        name: "{{ .App.Config.Secret.Name }}"
+        namespace: "{{ .App.Config.Secret.Namespace }}"
+    kubeConfig:
+      inCluster: {{ .App.KubeConfig.InCluster }}
+      secret:
+        name: "{{ .App.KubeConfig.Secret.Name }}"
+        namespace: "{{ .App.KubeConfig.Secret.Namespace }}"
+    version: "{{ .App.Version }}"
+  - name: "chart-operator"
+	namespace: "giantswarm"
+	catalog: "giantswarm-catalog"
+	kubeconfig:
+      inCluster: "true"
+    version: "0.9.0"
 
-appCatalog:
-  name: "{{ .AppCatalog.Name }}"
-  title: "{{ .AppCatalog.Title }}"
-  description: "{{ .AppCatalog.Description }}"
-  logoURL: "{{ .AppCatalog.LogoURL }}"
-  storage: 
-    type: "{{ .AppCatalog.Storage.Type }}" 
-    url: "{{ .AppCatalog.Storage.URL }}" 
+appCatalogs:
+  - name: "{{ .AppCatalog.Name }}"
+    title: "{{ .AppCatalog.Title }}"
+    description: "{{ .AppCatalog.Description }}"
+    logoURL: "{{ .AppCatalog.LogoURL }}"
+    storage: 
+      type: "{{ .AppCatalog.Storage.Type }}" 
+      url: "{{ .AppCatalog.Storage.URL }}" 
+  - name: "giantswarm-catalog"
+    title: "giantswarm-catalog"
+    description: "giantswarm catalog"
+    logoUrl: "http://giantswarm.com/catalog-logo.png"
+    storage:
+      type: "helm"
+      url: "https://giantswarm.github.com/giantswarm-catalog/"
 
 appOperator:
   version: "{{ .AppOperator.Version }}"
 
-configMap:
-  values: 
+configMaps:
+  {{ .App.Config.ConfigMap.Name }}: 
     {{ .ConfigMap.ValuesYAML }}
 
 namespace: "{{ .Namespace }}"
 
-secret:
-  values: 
+secrets:
+  {{ .App.Config.Secret.Name }}: 
     {{ .Secret.ValuesYAML }}`

--- a/pkg/chartvalues/apiextensions_app_e2e_template.go
+++ b/pkg/chartvalues/apiextensions_app_e2e_template.go
@@ -18,6 +18,7 @@ apps:
         name: "{{ .App.KubeConfig.Secret.Name }}"
         namespace: "{{ .App.KubeConfig.Secret.Namespace }}"
     version: "{{ .App.Version }}"
+  # Added chart-operator app CR for e2e testing purpose.
   - name: "chart-operator"
 	namespace: "giantswarm"
 	catalog: "giantswarm-catalog"

--- a/pkg/chartvalues/apiextensions_app_e2e_test.go
+++ b/pkg/chartvalues/apiextensions_app_e2e_test.go
@@ -75,44 +75,57 @@ func Test_NewAPIExtensionsAppE2E(t *testing.T) {
 			name:   "case 1: all values set",
 			config: newAPIExtensionsAppE2EConfigFromFilled(func(v *APIExtensionsAppE2EConfig) {}),
 			expectedValues: `
-app:
-  name: "test-app"
-  namespace: "default"
-  catalog: "test-app-catalog"
-  config:
-    configMap:
-      name: "test-app-values"
-      namespace: "default"
-    secret:
-      name: "test-app-secrets"
-      namespace: "default"
-  kubeConfig:
-    inCluster: false
-    secret:
-      name: "test-kubeconfig-secret"
-      namespace: "default"
-  version: "1.0.0"
+apps:
+  - name: "test-app"
+    namespace: "default"
+    catalog: "test-app-catalog"
+    config:
+      configMap:
+        name: "test-app-values"
+        namespace: "default"
+      secret:
+        name: "test-app-secrets"
+        namespace: "default"
+    kubeConfig:
+      inCluster: false
+      secret:
+        name: "test-kubeconfig-secret"
+        namespace: "default"
+    version: "1.0.0"
+  - name: "chart-operator"
+	namespace: "giantswarm"
+	catalog: "giantswarm-catalog"
+	kubeconfig:
+      inCluster: "true"
+    version: "0.9.0"
 
-appCatalog:
-  name: "test-app-catalog"
-  title: "test-app-catalog"
-  description: "giantswarm app catalog"
-  logoURL: "http://giantswarm.logo.catalog.png"
-  storage:
-    type: "helm"
-    url: "https://giantswarm.github.com/sample-catalog"
+appCatalogs:
+  - name: "test-app-catalog"
+    title: "test-app-catalog"
+    description: "giantswarm app catalog"
+    logoURL: "http://giantswarm.logo.catalog.png"
+    storage:
+      type: "helm"
+      url: "https://giantswarm.github.com/sample-catalog"
+  - name: "giantswarm-catalog"
+    title: "giantswarm-catalog"
+    description: "giantswarm catalog"
+    logoUrl: "http://giantswarm.com/catalog-logo.png"
+    storage:
+      type: "helm"
+      url: "https://giantswarm.github.com/giantswarm-catalog/"
 
 appOperator:
   version: "1.0.0"
 
-configMap:
-  values:
+configMaps:
+  test-app-values:
     test: "values"
 
 namespace: "default"
 
-secret:
-  values:
+secrets:
+  test-app-secrets:
     test: "secret"`,
 			errorMatcher: nil,
 		},

--- a/pkg/chartvalues/apiextensions_app_e2e_test.go
+++ b/pkg/chartvalues/apiextensions_app_e2e_test.go
@@ -92,6 +92,7 @@ apps:
         name: "test-kubeconfig-secret"
         namespace: "default"
     version: "1.0.0"
+  # Added chart-operator app CR for e2e testing purpose.
   - name: "chart-operator"
 	namespace: "giantswarm"
 	catalog: "giantswarm-catalog"


### PR DESCRIPTION
Toward https://github.com/giantswarm/app-operator/pull/120

it would support chart-operator `app` CR into e2e test. 