### PR TITLE
Fix indentation

### DIFF
--- a/pkg/chartvalues/apiextensions_app_e2e_template.go
+++ b/pkg/chartvalues/apiextensions_app_e2e_template.go
@@ -20,9 +20,9 @@ apps:
     version: "{{ .App.Version }}"
   # Added chart-operator app CR for e2e testing purpose.
   - name: "chart-operator"
-	namespace: "giantswarm"
-	catalog: "giantswarm-catalog"
-	kubeconfig:
+    namespace: "giantswarm"
+    catalog: "giantswarm-catalog"
+    kubeconfig:
       inCluster: "true"
     version: "0.9.0"
 
@@ -31,9 +31,9 @@ appCatalogs:
     title: "{{ .AppCatalog.Title }}"
     description: "{{ .AppCatalog.Description }}"
     logoURL: "{{ .AppCatalog.LogoURL }}"
-    storage: 
-      type: "{{ .AppCatalog.Storage.Type }}" 
-      url: "{{ .AppCatalog.Storage.URL }}" 
+    storage:
+      type: "{{ .AppCatalog.Storage.Type }}"
+      url: "{{ .AppCatalog.Storage.URL }}"
   - name: "giantswarm-catalog"
     title: "giantswarm-catalog"
     description: "giantswarm catalog"
@@ -46,11 +46,11 @@ appOperator:
   version: "{{ .AppOperator.Version }}"
 
 configMaps:
-  {{ .App.Config.ConfigMap.Name }}: 
+  {{ .App.Config.ConfigMap.Name }}:
     {{ .ConfigMap.ValuesYAML }}
 
 namespace: "{{ .Namespace }}"
 
 secrets:
-  {{ .App.Config.Secret.Name }}: 
+  {{ .App.Config.Secret.Name }}:
     {{ .Secret.ValuesYAML }}`

--- a/pkg/chartvalues/apiextensions_app_e2e_test.go
+++ b/pkg/chartvalues/apiextensions_app_e2e_test.go
@@ -94,9 +94,9 @@ apps:
     version: "1.0.0"
   # Added chart-operator app CR for e2e testing purpose.
   - name: "chart-operator"
-	namespace: "giantswarm"
-	catalog: "giantswarm-catalog"
-	kubeconfig:
+    namespace: "giantswarm"
+    catalog: "giantswarm-catalog"
+    kubeconfig:
       inCluster: "true"
     version: "0.9.0"
 


### PR DESCRIPTION
Once updated to include https://github.com/giantswarm/e2etemplates/pull/74 app-operator e2e tests were failing with:
```
{"caller":"github.com/giantswarm/app-operator/integration/test/app/basic/simple_test.go:69","level":"debug","message":"created chart value for release `apiextensions-app-e2e-chart`","time":"2019-08-22T16:08:41.174454+00:00"}
{"caller":"github.com/giantswarm/app-operator/integration/test/app/basic/simple_test.go:73","level":"debug","message":"installing release `apiextensions-app-e2e-chart`","time":"2019-08-22T16:08:41.174569+00:00"}
--- FAIL: TestAppLifecycle (0.61s)
    simple_test.go:78: expected <nil> got [{/go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/e2e-harness/pkg/release/release.go:271: } {/go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/helmclient/helmclient.go:320: } {/go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/helmclient/helmclient.go:365: } {/go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/helmclient/helmclient.go:344: } {rpc error: code = Unknown desc = error converting YAML to JSON: yaml: line 20: found character that cannot start any token}]
FAIL
```

This PR fixes problematic indentation in YAML string, and also removes trailing whitespaces.