### PR TITLE
Do not formatting using non-exist values

### DIFF
--- a/pkg/chartvalues/apiextensions_app_e2e_template.go
+++ b/pkg/chartvalues/apiextensions_app_e2e_template.go
@@ -5,18 +5,28 @@ apps:
   - name: "{{ .App.Name }}"
     namespace: "{{ .App.Namespace }}"
     catalog: "{{ .App.Catalog }}"
+{{- if .App.Config }}
     config:
+{{- if .App.Config.ConfigMap }}
       configMap:
         name: "{{ .App.Config.ConfigMap.Name }}"
         namespace: "{{ .App.Config.ConfigMap.Namespace }}"
+{{- end }}
+{{- if .App.Config.Secret }}
       secret:
         name: "{{ .App.Config.Secret.Name }}"
         namespace: "{{ .App.Config.Secret.Namespace }}"
+{{- end }}
+{{- end }}
+{{- if .App.KubeConfig }}
     kubeConfig:
       inCluster: {{ .App.KubeConfig.InCluster }}
+{{- if not .App.KubeConfig.InCluster }}
       secret:
         name: "{{ .App.KubeConfig.Secret.Name }}"
         namespace: "{{ .App.KubeConfig.Secret.Namespace }}"
+{{- end }}
+{{- end }}
     version: "{{ .App.Version }}"
   # Added chart-operator app CR for e2e testing purpose.
   - name: "chart-operator"
@@ -45,12 +55,16 @@ appCatalogs:
 appOperator:
   version: "{{ .AppOperator.Version }}"
 
+{{ if .App.Config.ConfigMap -}}
 configMaps:
   {{ .App.Config.ConfigMap.Name }}:
     {{ .ConfigMap.ValuesYAML }}
+{{- end }}
 
 namespace: "{{ .Namespace }}"
 
+{{ if .App.Config.Secret -}}
 secrets:
   {{ .App.Config.Secret.Name }}:
-    {{ .Secret.ValuesYAML }}`
+    {{ .Secret.ValuesYAML }}
+{{- end }}`

--- a/pkg/chartvalues/apiextensions_app_e2e_test.go
+++ b/pkg/chartvalues/apiextensions_app_e2e_test.go
@@ -1,6 +1,7 @@
 package chartvalues
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/giantswarm/e2etemplates/internal/rendertest"
@@ -151,6 +152,7 @@ secrets:
 				return
 			}
 
+			fmt.Println(values)
 			line, difference := rendertest.Diff(values, tc.expectedValues)
 			if line > 0 {
 				t.Fatalf("line == %d, want 0, diff: %s", line, difference)


### PR DESCRIPTION
Fixing the issue in app-operator
```
{"caller":"github.com/giantswarm/app-operator/integration/test/app/basic/simple_test.go:69","level":"debug","message":"created chart value for release `apiextensions-app-e2e-chart`","time":"2019-08-22T16:47:51.455038+00:00"}
{"caller":"github.com/giantswarm/app-operator/integration/test/app/basic/simple_test.go:73","level":"debug","message":"installing release `apiextensions-app-e2e-chart`","time":"2019-08-22T16:47:51.455068+00:00"}
--- FAIL: TestAppLifecycle (0.32s)
    simple_test.go:78: expected <nil> got [{/go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/e2e-harness/pkg/release/release.go:271: } {/go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/helmclient/helmclient.go:320: } {/go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/helmclient/helmclient.go:365: } {/go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/helmclient/helmclient.go:344: } {rpc error: code = Unknown desc = error converting YAML to JSON: yaml: line 46: did not find expected key}]
FAIL
```