### PR TITLE
Do not formatting nonexist cm and secret

### DIFF
--- a/pkg/chartvalues/apiextensions_app_e2e_template.go
+++ b/pkg/chartvalues/apiextensions_app_e2e_template.go
@@ -5,14 +5,14 @@ apps:
   - name: "{{ .App.Name }}"
     namespace: "{{ .App.Namespace }}"
     catalog: "{{ .App.Catalog }}"
-{{- if .App.Config }}
+{{- if or .App.Config.ConfigMap.Name .App.Config.Secret.Name }}
     config:
-{{- if .App.Config.ConfigMap }}
+{{- if .App.Config.ConfigMap.Name }}
       configMap:
         name: "{{ .App.Config.ConfigMap.Name }}"
         namespace: "{{ .App.Config.ConfigMap.Namespace }}"
 {{- end }}
-{{- if .App.Config.Secret }}
+{{- if .App.Config.Secret.Name }}
       secret:
         name: "{{ .App.Config.Secret.Name }}"
         namespace: "{{ .App.Config.Secret.Namespace }}"
@@ -55,7 +55,7 @@ appCatalogs:
 appOperator:
   version: "{{ .AppOperator.Version }}"
 
-{{ if .App.Config.ConfigMap -}}
+{{ if .App.Config.ConfigMap.Name -}}
 configMaps:
   {{ .App.Config.ConfigMap.Name }}:
     {{ .ConfigMap.ValuesYAML }}
@@ -63,7 +63,7 @@ configMaps:
 
 namespace: "{{ .Namespace }}"
 
-{{ if .App.Config.Secret -}}
+{{ if .App.Config.Secret.Name -}}
 secrets:
   {{ .App.Config.Secret.Name }}:
     {{ .Secret.ValuesYAML }}

--- a/pkg/chartvalues/apiextensions_app_e2e_test.go
+++ b/pkg/chartvalues/apiextensions_app_e2e_test.go
@@ -149,7 +149,7 @@ apps:
         name: "test-kubeconfig-secret"
         namespace: "default"
     version: "1.0.0"
-  # Added chart-operator app CR for e2e testing purpose.
+  # Added app CR for bootstrapping chart-operator
   - name: "chart-operator"
     namespace: "giantswarm"
     catalog: "giantswarm-catalog"

--- a/pkg/chartvalues/apiextensions_app_e2e_test.go
+++ b/pkg/chartvalues/apiextensions_app_e2e_test.go
@@ -7,6 +7,107 @@ import (
 	"github.com/giantswarm/e2etemplates/internal/rendertest"
 )
 
+const (
+	expectedValues = `
+apps:
+  - name: "test-app"
+    namespace: "default"
+    catalog: "test-app-catalog"
+    config:
+      configMap:
+        name: "test-app-values"
+        namespace: "default"
+      secret:
+        name: "test-app-secrets"
+        namespace: "default"
+    kubeConfig:
+      inCluster: false
+      secret:
+        name: "test-kubeconfig-secret"
+        namespace: "default"
+    version: "1.0.0"
+  # Added app CR for bootstrapping chart-operator
+  - name: "chart-operator"
+    namespace: "giantswarm"
+    catalog: "giantswarm-catalog"
+    kubeconfig:
+      inCluster: "true"
+    version: "0.9.0"
+
+appCatalogs:
+  - name: "test-app-catalog"
+    title: "test-app-catalog"
+    description: "giantswarm app catalog"
+    logoURL: "http://giantswarm.logo.catalog.png"
+    storage:
+      type: "helm"
+      url: "https://giantswarm.github.com/sample-catalog"
+  - name: "giantswarm-catalog"
+    title: "giantswarm-catalog"
+    description: "giantswarm catalog"
+    logoUrl: "http://giantswarm.com/catalog-logo.png"
+    storage:
+      type: "helm"
+      url: "https://giantswarm.github.com/giantswarm-catalog/"
+
+appOperator:
+  version: "1.0.0"
+
+configMaps:
+  test-app-values:
+    test: "values"
+
+namespace: "default"
+
+secrets:
+  test-app-secrets:
+    test: "secret"`
+
+	expectedValuesWithoutConfig = `
+apps:
+  - name: "test-app"
+    namespace: "default"
+    catalog: "test-app-catalog"
+    kubeConfig:
+      inCluster: false
+      secret:
+        name: "test-kubeconfig-secret"
+        namespace: "default"
+    version: "1.0.0"
+  # Added app CR for bootstrapping chart-operator
+  - name: "chart-operator"
+    namespace: "giantswarm"
+    catalog: "giantswarm-catalog"
+    kubeconfig:
+      inCluster: "true"
+    version: "0.9.0"
+
+appCatalogs:
+  - name: "test-app-catalog"
+    title: "test-app-catalog"
+    description: "giantswarm app catalog"
+    logoURL: "http://giantswarm.logo.catalog.png"
+    storage:
+      type: "helm"
+      url: "https://giantswarm.github.com/sample-catalog"
+  - name: "giantswarm-catalog"
+    title: "giantswarm-catalog"
+    description: "giantswarm catalog"
+    logoUrl: "http://giantswarm.com/catalog-logo.png"
+    storage:
+      type: "helm"
+      url: "https://giantswarm.github.com/giantswarm-catalog/"
+
+appOperator:
+  version: "1.0.0"
+
+
+
+namespace: "default"
+
+`
+)
+
 func newAPIExtensionsAppE2EConfigFromFilled(modifyFunc func(*APIExtensionsAppE2EConfig)) APIExtensionsAppE2EConfig {
 	c := APIExtensionsAppE2EConfig{
 		App: APIExtensionsAppE2EConfigApp{
@@ -77,111 +178,16 @@ func Test_NewAPIExtensionsAppE2E(t *testing.T) {
 			errorMatcher:   IsInvalidConfig,
 		},
 		{
-			name:   "case 1: all values set",
-			config: newAPIExtensionsAppE2EConfigFromFilled(func(v *APIExtensionsAppE2EConfig) {}),
-			expectedValues: `
-apps:
-  - name: "test-app"
-    namespace: "default"
-    catalog: "test-app-catalog"
-    config:
-      configMap:
-        name: "test-app-values"
-        namespace: "default"
-      secret:
-        name: "test-app-secrets"
-        namespace: "default"
-    kubeConfig:
-      inCluster: false
-      secret:
-        name: "test-kubeconfig-secret"
-        namespace: "default"
-    version: "1.0.0"
-  # Added app CR for bootstrapping chart-operator
-  - name: "chart-operator"
-    namespace: "giantswarm"
-    catalog: "giantswarm-catalog"
-    kubeconfig:
-      inCluster: "true"
-    version: "0.9.0"
-
-appCatalogs:
-  - name: "test-app-catalog"
-    title: "test-app-catalog"
-    description: "giantswarm app catalog"
-    logoURL: "http://giantswarm.logo.catalog.png"
-    storage:
-      type: "helm"
-      url: "https://giantswarm.github.com/sample-catalog"
-  - name: "giantswarm-catalog"
-    title: "giantswarm-catalog"
-    description: "giantswarm catalog"
-    logoUrl: "http://giantswarm.com/catalog-logo.png"
-    storage:
-      type: "helm"
-      url: "https://giantswarm.github.com/giantswarm-catalog/"
-
-appOperator:
-  version: "1.0.0"
-
-configMaps:
-  test-app-values:
-    test: "values"
-
-namespace: "default"
-
-secrets:
-  test-app-secrets:
-    test: "secret"`,
-			errorMatcher: nil,
+			name:           "case 1: all values set",
+			config:         newAPIExtensionsAppE2EConfigFromFilled(func(v *APIExtensionsAppE2EConfig) {}),
+			expectedValues: expectedValues,
+			errorMatcher:   nil,
 		},
 		{
-			name:   "case 2: no configmap and secret",
-			config: newAPIExtensionsAppE2EConfigFromFilled(removeConfigMapAndSecret),
-			expectedValues: `
-apps:
-  - name: "test-app"
-    namespace: "default"
-    catalog: "test-app-catalog"
-    kubeConfig:
-      inCluster: false
-      secret:
-        name: "test-kubeconfig-secret"
-        namespace: "default"
-    version: "1.0.0"
-  # Added app CR for bootstrapping chart-operator
-  - name: "chart-operator"
-    namespace: "giantswarm"
-    catalog: "giantswarm-catalog"
-    kubeconfig:
-      inCluster: "true"
-    version: "0.9.0"
-
-appCatalogs:
-  - name: "test-app-catalog"
-    title: "test-app-catalog"
-    description: "giantswarm app catalog"
-    logoURL: "http://giantswarm.logo.catalog.png"
-    storage:
-      type: "helm"
-      url: "https://giantswarm.github.com/sample-catalog"
-  - name: "giantswarm-catalog"
-    title: "giantswarm-catalog"
-    description: "giantswarm catalog"
-    logoUrl: "http://giantswarm.com/catalog-logo.png"
-    storage:
-      type: "helm"
-      url: "https://giantswarm.github.com/giantswarm-catalog/"
-
-appOperator:
-  version: "1.0.0"
-
-
-
-namespace: "default"
-
-`,
-			errorMatcher: nil,
+			name:           "case 2: no configmap and secret",
+			config:         newAPIExtensionsAppE2EConfigFromFilled(removeConfigMapAndSecret),
+			expectedValues: expectedValuesWithoutConfig,
+			errorMatcher:   nil,
 		},
 	}
 

--- a/pkg/chartvalues/apiextensions_app_e2e_test.go
+++ b/pkg/chartvalues/apiextensions_app_e2e_test.go
@@ -59,6 +59,10 @@ func newAPIExtensionsAppE2EConfigFromFilled(modifyFunc func(*APIExtensionsAppE2E
 	return c
 }
 
+func removeConfigMapAndSecret(v *APIExtensionsAppE2EConfig) {
+	v.App.Config = APIExtensionsAppE2EConfigAppConfig{}
+}
+
 func Test_NewAPIExtensionsAppE2E(t *testing.T) {
 	testCases := []struct {
 		name           string
@@ -129,6 +133,54 @@ namespace: "default"
 secrets:
   test-app-secrets:
     test: "secret"`,
+			errorMatcher: nil,
+		},
+		{
+			name:   "case 2: no configmap and secret",
+			config: newAPIExtensionsAppE2EConfigFromFilled(removeConfigMapAndSecret),
+			expectedValues: `
+apps:
+  - name: "test-app"
+    namespace: "default"
+    catalog: "test-app-catalog"
+    kubeConfig:
+      inCluster: false
+      secret:
+        name: "test-kubeconfig-secret"
+        namespace: "default"
+    version: "1.0.0"
+  # Added chart-operator app CR for e2e testing purpose.
+  - name: "chart-operator"
+    namespace: "giantswarm"
+    catalog: "giantswarm-catalog"
+    kubeconfig:
+      inCluster: "true"
+    version: "0.9.0"
+
+appCatalogs:
+  - name: "test-app-catalog"
+    title: "test-app-catalog"
+    description: "giantswarm app catalog"
+    logoURL: "http://giantswarm.logo.catalog.png"
+    storage:
+      type: "helm"
+      url: "https://giantswarm.github.com/sample-catalog"
+  - name: "giantswarm-catalog"
+    title: "giantswarm-catalog"
+    description: "giantswarm catalog"
+    logoUrl: "http://giantswarm.com/catalog-logo.png"
+    storage:
+      type: "helm"
+      url: "https://giantswarm.github.com/giantswarm-catalog/"
+
+appOperator:
+  version: "1.0.0"
+
+
+
+namespace: "default"
+
+`,
 			errorMatcher: nil,
 		},
 	}


### PR DESCRIPTION
To resolve an issue with e2e test on app-operator, we need to wrap around cm, secret with if statements that do not need to create.