### PR TITLE
Remove chart-operator related values

### DIFF
--- a/pkg/chartvalues/apiextensions_app_e2e_template.go
+++ b/pkg/chartvalues/apiextensions_app_e2e_template.go
@@ -28,13 +28,6 @@ apps:
 {{- end }}
 {{- end }}
     version: "{{ .App.Version }}"
-  # Added app CR for bootstrapping chart-operator
-  - name: "chart-operator"
-    namespace: "giantswarm"
-    catalog: "giantswarm-catalog"
-    kubeConfig:
-      inCluster: true
-    version: "0.9.0"
 
 appCatalogs:
   - name: "{{ .AppCatalog.Name }}"
@@ -44,13 +37,6 @@ appCatalogs:
     storage:
       type: "{{ .AppCatalog.Storage.Type }}"
       url: "{{ .AppCatalog.Storage.URL }}"
-  - name: "giantswarm-catalog"
-    title: "giantswarm-catalog"
-    description: "giantswarm catalog"
-    logoUrl: "http://giantswarm.com/catalog-logo.png"
-    storage:
-      type: "helm"
-      url: "https://giantswarm.github.com/giantswarm-catalog/"
 
 appOperator:
   version: "{{ .AppOperator.Version }}"

--- a/pkg/chartvalues/apiextensions_app_e2e_test.go
+++ b/pkg/chartvalues/apiextensions_app_e2e_test.go
@@ -26,13 +26,6 @@ apps:
         name: "test-kubeconfig-secret"
         namespace: "default"
     version: "1.0.0"
-  # Added app CR for bootstrapping chart-operator
-  - name: "chart-operator"
-    namespace: "giantswarm"
-    catalog: "giantswarm-catalog"
-    kubeConfig:
-      inCluster: true
-    version: "0.9.0"
 
 appCatalogs:
   - name: "test-app-catalog"
@@ -42,13 +35,6 @@ appCatalogs:
     storage:
       type: "helm"
       url: "https://giantswarm.github.com/sample-catalog"
-  - name: "giantswarm-catalog"
-    title: "giantswarm-catalog"
-    description: "giantswarm catalog"
-    logoUrl: "http://giantswarm.com/catalog-logo.png"
-    storage:
-      type: "helm"
-      url: "https://giantswarm.github.com/giantswarm-catalog/"
 
 appOperator:
   version: "1.0.0"
@@ -74,13 +60,6 @@ apps:
         name: "test-kubeconfig-secret"
         namespace: "default"
     version: "1.0.0"
-  # Added app CR for bootstrapping chart-operator
-  - name: "chart-operator"
-    namespace: "giantswarm"
-    catalog: "giantswarm-catalog"
-    kubeConfig:
-      inCluster: true
-    version: "0.9.0"
 
 appCatalogs:
   - name: "test-app-catalog"
@@ -90,13 +69,6 @@ appCatalogs:
     storage:
       type: "helm"
       url: "https://giantswarm.github.com/sample-catalog"
-  - name: "giantswarm-catalog"
-    title: "giantswarm-catalog"
-    description: "giantswarm catalog"
-    logoUrl: "http://giantswarm.com/catalog-logo.png"
-    storage:
-      type: "helm"
-      url: "https://giantswarm.github.com/giantswarm-catalog/"
 
 appOperator:
   version: "1.0.0"


### PR DESCRIPTION
Found a problem during giantswarm/app-operator#130.

chart-operator app CR should be separated from e2etemplates values. 
If e2e test deletes the release, it would delete chart-operator, too. 🤦‍♂