### PR TITLE
Fix aws-operator e2e template

### DIFF
--- a/pkg/chartvalues/aws_operator_template.go
+++ b/pkg/chartvalues/aws_operator_template.go
@@ -73,6 +73,6 @@ const awsOperatorTemplate = `Installation:
         Enabled: false
         GSAPI: false
         GuestAPI:
-          Public: false
           Private: false
+          Public: false
 `

--- a/pkg/chartvalues/aws_operator_template.go
+++ b/pkg/chartvalues/aws_operator_template.go
@@ -71,4 +71,8 @@ const awsOperatorTemplate = `Installation:
     Security:
       RestrictAccess:
         Enabled: false
+        GSAPI: false
+        GuestAPI:
+          Public: false
+          Private: false
 `

--- a/pkg/chartvalues/aws_operator_test.go
+++ b/pkg/chartvalues/aws_operator_test.go
@@ -133,6 +133,10 @@ func Test_NewAWSOperator(t *testing.T) {
     Security:
       RestrictAccess:
         Enabled: false
+        GSAPI: false
+        GuestAPI:
+          Private: false
+          Public: false
 `,
 			errorMatcher: nil,
 		},
@@ -214,6 +218,10 @@ func Test_NewAWSOperator(t *testing.T) {
     Security:
       RestrictAccess:
         Enabled: false
+        GSAPI: false
+        GuestAPI:
+          Private: false
+          Public: false
 `,
 			errorMatcher: nil,
 		},


### PR DESCRIPTION
@calvix found this issue after my PR into whitelisting refactoring

```
{"caller":"github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/helmclient/helmclient.go:354","level":"debug","message":"err string: `rpc error: code = Unknown desc = render error in \"aws-operator-chart/templates/configmap.yaml\": template: aws-operator-chart/templates/configmap.yaml:76:39: executing \"aws-operator-chart/templates/configmap.yaml\" at \u003c.Values.Installation...\u003e: can't evaluate field Public in type interface {}`","time":"2019-09-30T13:29:18.945511+00:00"}
{"caller":"github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/backoff/notifier.go:13","level":"warning","message":"retrying backoff in '5s' due to error","stack":"[{/go/src/github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/helmclient/helmclient.go:355: } {rpc error: code = Unknown desc = render error in \"aws-operator-chart/templates/configmap.yaml\": template: aws-operator-chart/templates/configmap.yaml:76:39: executing \"aws-operator-chart/templates/configmap.yaml\" at \u003c.Values.Installation...\u003e: can't evaluate field Public in type interface {}}]","time":"2019-09-30T13:29:18.945623+00:00"}
{"caller":"github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/helmclient/helmclient.go:354","level":"debug","message":"err string: `rpc error: code = Unknown desc = render error in \"aws-operator-chart/templates/configmap.yaml\": template: aws-operator-chart/templates/configmap.yaml:76:39: executing \"aws-operator-chart/templates/configmap.yaml\" at \u003c.Values.Installation...\u003e: can't evaluate field Public in type interface {}`","time":"2019-09-30T13:29:24.056317+00:00"}
```

Fixing templates as I didn't rely on e2e tests, therefore didn't run them