### PR TITLE
Allow to pass more parameters

### DIFF
--- a/pkg/chartvalues/apiextensions_azure_config_e2e.go
+++ b/pkg/chartvalues/apiextensions_azure_config_e2e.go
@@ -11,6 +11,8 @@ type APIExtensionsAzureConfigE2EConfig struct {
 	ClusterName               string
 	CommonDomain              string
 	CommonDomainResourceGroup string
+	SSHPublicKey              string
+	SSHUser                   string
 	VersionBundleVersion      string
 }
 
@@ -64,6 +66,12 @@ func NewAPIExtensionsAzureConfigE2E(config APIExtensionsAzureConfigE2EConfig) (s
 	}
 	if config.CommonDomainResourceGroup == "" {
 		return "", microerror.Maskf(invalidConfigError, "%T.CommonDomainResourceGroup must not be empty", config)
+	}
+	if config.SSHPublicKey == "" {
+		return "", microerror.Maskf(invalidConfigError, "%T.SSHPublicKey must not be empty", config)
+	}
+	if config.SSHUser == "" {
+		return "", microerror.Maskf(invalidConfigError, "%T.SSHUser must not be empty", config)
 	}
 	if config.VersionBundleVersion == "" {
 		return "", microerror.Maskf(invalidConfigError, "%T.VersionBundleVersion must not be empty", config)

--- a/pkg/chartvalues/apiextensions_azure_config_e2e_template.go
+++ b/pkg/chartvalues/apiextensions_azure_config_e2e_template.go
@@ -19,5 +19,7 @@ azure:
 clusterName: {{ .ClusterName }}
 commonDomain: {{ .CommonDomain }}
 commonDomainResourceGroup: {{ .CommonDomainResourceGroup }}
+sshPublicKey: {{ .SSHPublicKey }}
+sshUser: {{ .SSHUser }}
 versionBundleVersion: {{ .VersionBundleVersion }}
 `

--- a/pkg/chartvalues/apiextensions_azure_config_e2e_test.go
+++ b/pkg/chartvalues/apiextensions_azure_config_e2e_test.go
@@ -22,6 +22,8 @@ func newAPIExtensionsAzureConfigE2EConfigFromFilled(modifyFunc func(*APIExtensio
 		ClusterName:               "test-cluster-name",
 		CommonDomain:              "test-common-domain",
 		CommonDomainResourceGroup: "test-common-domain-resource-group",
+		SSHPublicKey:              "some-ssh-public-key",
+		SSHUser:                   "test-user",
 		VersionBundleVersion:      "test-version-bundle-version",
 	}
 
@@ -59,6 +61,8 @@ azure:
 clusterName: test-cluster-name
 commonDomain: test-common-domain
 commonDomainResourceGroup: test-common-domain-resource-group
+sshPublicKey: some-ssh-public-key
+sshUser: test-user
 versionBundleVersion: test-version-bundle-version
 `,
 			errorMatcher: nil,
@@ -82,6 +86,8 @@ azure:
 clusterName: test-cluster-name
 commonDomain: test-common-domain
 commonDomainResourceGroup: test-common-domain-resource-group
+sshPublicKey: some-ssh-public-key
+sshUser: test-user
 versionBundleVersion: test-version-bundle-version
 `,
 			errorMatcher: nil,
@@ -185,7 +191,21 @@ func Test_NewAPIExtensionsAzureConfigE2E_invalidConfigError(t *testing.T) {
 			errorMatcher: IsInvalidConfig,
 		},
 		{
-			name: "case 9: invalid .VersionBundleVersion",
+			name: "case 9: invalid .SSHPublicKey",
+			config: newAPIExtensionsAzureConfigE2EConfigFromFilled(func(v *APIExtensionsAzureConfigE2EConfig) {
+				v.SSHPublicKey = ""
+			}),
+			errorMatcher: IsInvalidConfig,
+		},
+		{
+			name: "case 10: invalid .SSHUser",
+			config: newAPIExtensionsAzureConfigE2EConfigFromFilled(func(v *APIExtensionsAzureConfigE2EConfig) {
+				v.SSHUser = ""
+			}),
+			errorMatcher: IsInvalidConfig,
+		},
+		{
+			name: "case 11: invalid .VersionBundleVersion",
 			config: newAPIExtensionsAzureConfigE2EConfigFromFilled(func(v *APIExtensionsAzureConfigE2EConfig) {
 				v.VersionBundleVersion = ""
 			}),

--- a/pkg/chartvalues/azure_operator.go
+++ b/pkg/chartvalues/azure_operator.go
@@ -16,7 +16,8 @@ type AzureOperatorConfigProvider struct {
 }
 
 type AzureOperatorConfigProviderAzure struct {
-	Location string
+	Location        string
+	HostClusterCidr string
 }
 
 type AzureOperatorConfigSecret struct {

--- a/pkg/chartvalues/azure_operator_template.go
+++ b/pkg/chartvalues/azure_operator_template.go
@@ -31,7 +31,7 @@ Installation:
         # TODO rename to EnvironmentName. See https://github.com/giantswarm/giantswarm/issues/4124.
         Cloud: AZUREPUBLICCLOUD
         HostCluster:
-          CIDR: "0.0.0.0/0"
+          CIDR: "{{ .Provider.Azure.HostClusterCidr }}"
           ResourceGroup: "godsmack"
           VirtualNetwork: "godsmack"
           VirtualNetworkGateway: "godsmack-vpn-gateway"

--- a/pkg/chartvalues/azure_operator_template.go
+++ b/pkg/chartvalues/azure_operator_template.go
@@ -31,7 +31,7 @@ Installation:
         # TODO rename to EnvironmentName. See https://github.com/giantswarm/giantswarm/issues/4124.
         Cloud: AZUREPUBLICCLOUD
         HostCluster:
-          CIDR: "10.0.0.0/16"
+          CIDR: "0.0.0.0/0"
           ResourceGroup: "godsmack"
           VirtualNetwork: "godsmack"
           VirtualNetworkGateway: "godsmack-vpn-gateway"

--- a/pkg/chartvalues/azure_operator_test.go
+++ b/pkg/chartvalues/azure_operator_test.go
@@ -10,7 +10,8 @@ func newAzureOperatorConfigFromFilled(modifyFunc func(*AzureOperatorConfig)) Azu
 	c := AzureOperatorConfig{
 		Provider: AzureOperatorConfigProvider{
 			Azure: AzureOperatorConfigProviderAzure{
-				Location: "test-location",
+				HostClusterCidr: "10.0.0.0/16",
+				Location:        "test-location",
 			},
 		},
 		Secret: AzureOperatorConfigSecret{


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7982

These changes are required so [here I can spin up a bastion instance](https://github.com/giantswarm/azure-operator/pull/637) during e2e execution just in case we need further debugging.

Changes include:
- Allow to pass SSH configuration as parameter
- Allow to pass control plane CIDR as parameter